### PR TITLE
#24 [장소 검색 화면] 검색어 입력 및 데이터 출력

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ plugins {
     id 'kotlin-android-extensions'
 }
 
-// Properties properties = new Properties()
-// properties.load(project.rootProject.file("local.properties").newDataInputStream())
+Properties properties = new Properties()
+properties.load(project.rootProject.file("local.properties").newDataInputStream())
 
 android {
     compileSdk 31
@@ -21,6 +21,7 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField "String", "GOOGLE_MAP_KEY", properties["google_map_key"]
         // buildConfigField "String", "TOUR_API_KEY", properties["tour_api_key"]
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ plugins {
     id 'kotlin-android-extensions'
 }
 
-Properties properties = new Properties()
-properties.load(project.rootProject.file("local.properties").newDataInputStream())
+// Properties properties = new Properties()
+// properties.load(project.rootProject.file("local.properties").newDataInputStream())
 
 android {
     compileSdk 31
@@ -21,7 +21,7 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField "String", "GOOGLE_MAP_KEY", properties["google_map_key"]
+        // buildConfigField "String", "GOOGLE_MAP_KEY", properties["google_map_key"]
         // buildConfigField "String", "TOUR_API_KEY", properties["tour_api_key"]
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/Theme.AppCompat.Light.NoActionBar">
         <activity
             android:name=".MainActivity"
+            android:windowSoftInputMode="adjustPan"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/thequietz/travelog/api/PlaceSearchService.kt
+++ b/app/src/main/java/com/thequietz/travelog/api/PlaceSearchService.kt
@@ -1,0 +1,30 @@
+package com.thequietz.travelog.api
+
+import com.thequietz.travelog.place.model.PlaceSearchModelResponse
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface PlaceSearchService {
+
+    @GET("maps/api/place/textsearch/json")
+    fun searchPlaceList(
+        @Query("query") query: String,
+        @Query("key") key: String
+    ): Call<PlaceSearchModelResponse>
+
+    companion object {
+        private const val apiUrl = "https://maps.googleapis.com/"
+
+        fun create(): PlaceSearchService {
+            return Retrofit
+                .Builder()
+                .baseUrl(apiUrl)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(PlaceSearchService::class.java)
+        }
+    }
+}

--- a/app/src/main/java/com/thequietz/travelog/di/NetworkModule.kt
+++ b/app/src/main/java/com/thequietz/travelog/di/NetworkModule.kt
@@ -1,5 +1,6 @@
 package com.thequietz.travelog.di
 
+import com.thequietz.travelog.api.PlaceSearchService
 import com.thequietz.travelog.api.PlaceService
 import dagger.Module
 import dagger.Provides
@@ -15,5 +16,11 @@ object NetworkModule {
     @Provides
     fun providePlaceService(): PlaceService {
         return PlaceService.create()
+    }
+
+    @Singleton
+    @Provides
+    fun providePlaceSearchService(): PlaceSearchService {
+        return PlaceSearchService.create()
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceSearchAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceSearchAdapter.kt
@@ -1,0 +1,59 @@
+package com.thequietz.travelog.place.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.thequietz.travelog.R
+import com.thequietz.travelog.databinding.ItemRecyclerPlaceSearchBinding
+import com.thequietz.travelog.place.model.PlaceSearchModel
+
+class PlaceSearchAdapter(
+    private val listener: PlaceSearchAdapter.OnItemClickListener
+) :
+    ListAdapter<PlaceSearchModel, PlaceSearchAdapter.ViewHolder>(diffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding: ItemRecyclerPlaceSearchBinding = DataBindingUtil.inflate(
+            LayoutInflater.from(parent.context),
+            R.layout.item_recycler_place_search,
+            parent,
+            false
+        )
+        val viewHolder = ViewHolder(binding)
+        return viewHolder
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position), position)
+    }
+
+    inner class ViewHolder(private val binding: ItemRecyclerPlaceSearchBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(model: PlaceSearchModel, position: Int) {
+            binding.model = model
+            binding.tvPlaceSearchItem.setOnClickListener {
+                listener.onClickItem(model, position)
+            }
+
+            binding.executePendingBindings()
+        }
+    }
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<PlaceSearchModel>() {
+            override fun areItemsTheSame(oldItem: PlaceSearchModel, newItem: PlaceSearchModel) =
+                oldItem.placeId == newItem.placeId
+
+            override fun areContentsTheSame(oldItem: PlaceSearchModel, newItem: PlaceSearchModel) =
+                oldItem == newItem
+        }
+    }
+
+    interface OnItemClickListener {
+        fun onClickItem(model: PlaceSearchModel, position: Int): Boolean
+    }
+}

--- a/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceSearchDiffUtil.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceSearchDiffUtil.kt
@@ -1,0 +1,14 @@
+package com.thequietz.travelog.place.adapter
+
+import androidx.recyclerview.widget.DiffUtil
+import com.thequietz.travelog.place.model.PlaceSearchModel
+
+object PlaceSearchDiffUtil : DiffUtil.ItemCallback<PlaceSearchModel>() {
+    override fun areItemsTheSame(oldItem: PlaceSearchModel, newItem: PlaceSearchModel): Boolean {
+        return oldItem.placeId == newItem.placeId
+    }
+
+    override fun areContentsTheSame(oldItem: PlaceSearchModel, newItem: PlaceSearchModel): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/app/src/main/java/com/thequietz/travelog/place/model/PlaceSearchModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/model/PlaceSearchModel.kt
@@ -1,0 +1,32 @@
+package com.thequietz.travelog.place.model
+
+import com.google.gson.annotations.SerializedName
+
+data class PlaceSearchModelResponse(
+    @SerializedName("results")
+    val results: List<PlaceSearchModel>,
+)
+
+data class PlaceSearchModel(
+    @SerializedName("name")
+    val name: String,
+
+    @SerializedName("place_id")
+    val placeId: String,
+
+    @SerializedName("geometry")
+    val geometry: PlaceGeometry,
+)
+
+data class PlaceGeometry(
+    @SerializedName("location")
+    val location: PlaceLocation
+)
+
+data class PlaceLocation(
+    @SerializedName("lat")
+    val latitude: Double,
+
+    @SerializedName("lng")
+    val longitude: Double,
+)

--- a/app/src/main/java/com/thequietz/travelog/place/repository/PlaceSearchRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/repository/PlaceSearchRepository.kt
@@ -1,6 +1,5 @@
 package com.thequietz.travelog.place.repository
 
-import com.thequietz.travelog.BuildConfig
 import com.thequietz.travelog.api.PlaceSearchService
 import com.thequietz.travelog.place.model.PlaceSearchModel
 import retrofit2.awaitResponse
@@ -10,7 +9,7 @@ class PlaceSearchRepository @Inject constructor(
     private val service: PlaceSearchService,
 ) {
     suspend fun loadPlaceList(query: String): List<PlaceSearchModel> {
-        val apiKey: String = BuildConfig.GOOGLE_MAP_KEY
+        val apiKey = "" // BuildConfig.GOOGLE_MAP_KEY
         val call = service.searchPlaceList(query, apiKey)
         val response = call.awaitResponse()
         if (!response.isSuccessful || response.body() == null) {

--- a/app/src/main/java/com/thequietz/travelog/place/repository/PlaceSearchRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/repository/PlaceSearchRepository.kt
@@ -1,0 +1,21 @@
+package com.thequietz.travelog.place.repository
+
+import com.thequietz.travelog.BuildConfig
+import com.thequietz.travelog.api.PlaceSearchService
+import com.thequietz.travelog.place.model.PlaceSearchModel
+import retrofit2.awaitResponse
+import javax.inject.Inject
+
+class PlaceSearchRepository @Inject constructor(
+    private val service: PlaceSearchService,
+) {
+    suspend fun loadPlaceList(query: String): List<PlaceSearchModel> {
+        val apiKey: String = BuildConfig.GOOGLE_MAP_KEY
+        val call = service.searchPlaceList(query, apiKey)
+        val response = call.awaitResponse()
+        if (!response.isSuccessful || response.body() == null) {
+            return listOf()
+        }
+        return response.body()?.results ?: listOf()
+    }
+}

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceDetailFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceDetailFragment.kt
@@ -1,0 +1,23 @@
+package com.thequietz.travelog.place.view
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.thequietz.travelog.R
+
+class PlaceDetailFragment : Fragment() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_place_detail, container, false)
+    }
+}

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
@@ -1,0 +1,84 @@
+package com.thequietz.travelog.place.view
+
+import android.content.Context
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.gson.Gson
+import com.thequietz.travelog.R
+import com.thequietz.travelog.databinding.FragmentPlaceSearchBinding
+import com.thequietz.travelog.place.adapter.PlaceSearchAdapter
+import com.thequietz.travelog.place.model.PlaceSearchModel
+import com.thequietz.travelog.place.viewmodel.PlaceSearchViewModel
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class PlaceSearchFragment : Fragment() {
+
+    private var _binding: FragmentPlaceSearchBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: PlaceSearchViewModel by viewModels()
+
+    private lateinit var adapter: PlaceSearchAdapter
+    private lateinit var _context: Context
+    private lateinit var gson: Gson
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding =
+            DataBindingUtil.inflate(inflater, R.layout.fragment_place_search, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        _context = requireContext()
+        gson = Gson()
+
+        adapter = PlaceSearchAdapter(object : PlaceSearchAdapter.OnItemClickListener {
+            override fun onClickItem(model: PlaceSearchModel, position: Int): Boolean {
+                val param = gson.toJson(model)
+                Log.d("Place", param)
+                return true
+            }
+        })
+        binding.rvPlaceSearch.adapter = adapter
+        binding.rvPlaceSearch.layoutManager = LinearLayoutManager(_context)
+        binding.rvPlaceSearch.addItemDecoration(
+            DividerItemDecoration(
+                _context,
+                LinearLayoutManager.VERTICAL
+            )
+        )
+        binding.viewModel = viewModel
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.etPlaceSearch.setOnKeyListener { v, code, _ ->
+            if (code !== android.view.KeyEvent.KEYCODE_ENTER) return@setOnKeyListener false
+            val query = (v as EditText).text.toString()
+            viewModel.loadPlaceList(query)
+            true
+        }
+
+        viewModel.place.observe(viewLifecycleOwner, {
+            (binding.rvPlaceSearch.adapter as PlaceSearchAdapter).submitList(it)
+        })
+
+        viewModel.initPlaceList()
+    }
+}

--- a/app/src/main/java/com/thequietz/travelog/place/viewmodel/PlaceSearchViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/viewmodel/PlaceSearchViewModel.kt
@@ -1,0 +1,36 @@
+package com.thequietz.travelog.place.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.thequietz.travelog.place.model.PlaceSearchModel
+import com.thequietz.travelog.place.repository.PlaceSearchRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class PlaceSearchViewModel @Inject constructor(
+    private val repository: PlaceSearchRepository
+) : ViewModel() {
+    private var _place = MutableLiveData<List<PlaceSearchModel>>()
+    val place: LiveData<List<PlaceSearchModel>> get() = _place
+
+    val query = MutableLiveData<String>()
+
+    fun initPlaceList() {
+        _place.value = listOf()
+    }
+
+    fun loadPlaceList(query: String) {
+        viewModelScope.launch {
+            val placeList = repository.loadPlaceList(query)
+            _place.value = placeList
+        }
+    }
+
+    fun onClickBackButton() {
+        _place.value = listOf()
+    }
+}

--- a/app/src/main/java/com/thequietz/travelog/schedule/view/SchedulePlaceFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/view/SchedulePlaceFragment.kt
@@ -100,6 +100,11 @@ class SchedulePlaceFragment : Fragment() {
             it.findNavController().navigate(action)
         }
 
+        binding.btnSearchPlace.setOnClickListener {
+            val action = SchedulePlaceFragmentDirections.actionSchedulePlaceFragmentToPlaceSearchFragment()
+            it.findNavController().navigate(action)
+        }
+
         viewModel.placeList.observe(viewLifecycleOwner, {
 
             binding.tvEmptyResult.visibility = if (it.isEmpty()) {

--- a/app/src/main/res/layout/fragment_place_detail.xml
+++ b/app/src/main/res/layout/fragment_place_detail.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".place.view.PlaceDetailFragment">
+
+        <LinearLayout
+            android:id="@+id/ll_google_map_detail"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/purple_200"
+            android:gravity="center_vertical"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toTopOf="@id/ll_place_detail"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:text="@string/tv_google_map_view"
+                android:textColor="@color/black"
+                android:textSize="30sp"
+                android:textStyle="bold" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/ll_place_detail"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="20dp"
+            android:paddingVertical="10dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHeight_max="200dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ll_google_map_detail">
+
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_place_search.xml
+++ b/app/src/main/res/layout/fragment_place_search.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.thequietz.travelog.place.viewmodel.PlaceSearchViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".place.view.PlaceSearchFragment">
+
+        <EditText
+            android:id="@+id/et_place_search"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="20dp"
+            android:background="@color/et_search"
+            android:drawableEnd="@drawable/ic_search"
+            android:importantForAutofill="no"
+            android:inputType="text"
+            android:singleLine="true"
+            android:text="@={viewModel.query}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0"
+            app:layout_constraintVertical_chainStyle="packed" />
+
+        <LinearLayout
+            android:id="@+id/ll_google_map"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="20dp"
+            android:background="@color/purple_200"
+            android:gravity="center_vertical"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toTopOf="@id/rv_place_search"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/et_place_search">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:text="@string/tv_google_map_view"
+                android:textColor="@color/black"
+                android:textSize="30sp"
+                android:textStyle="bold" />
+
+        </LinearLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_place_search"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="20dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHeight_max="300dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ll_google_map" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_schedule_place.xml
+++ b/app/src/main/res/layout/fragment_schedule_place.xml
@@ -34,8 +34,21 @@
             android:layout_marginStart="10dp"
             android:text="@string/btn_search"
             app:layout_constraintBottom_toBottomOf="@id/et_search"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/btn_search_place"
             app:layout_constraintStart_toEndOf="@id/et_search"
+            app:layout_constraintTop_toTopOf="@id/et_search" />
+
+        <Button
+            android:id="@+id/btn_search_place"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:minWidth="0dp"
+            android:paddingHorizontal="12dp"
+            android:text="@string/btn_search_place"
+            app:layout_constraintBottom_toBottomOf="@id/et_search"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/btn_select_date"
             app:layout_constraintTop_toTopOf="@id/et_search" />
 
         <TextView

--- a/app/src/main/res/layout/item_recycler_place_search.xml
+++ b/app/src/main/res/layout/item_recycler_place_search.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="model"
+            type="com.thequietz.travelog.place.model.PlaceSearchModel" />
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/tv_place_search_item"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingVertical="15dp"
+            android:text="@{model.name}"
+            android:textSize="20sp"
+            tools:text="@string/tv_place_search_item" />
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -40,6 +40,9 @@
         <action
             android:id="@+id/action_schedulePlaceFragment_to_scheduleSelectFragment"
             app:destination="@id/scheduleSelectFragment" />
+        <action
+            android:id="@+id/action_schedulePlaceFragment_to_placeSearchFragment"
+            app:destination="@id/placeSearchFragment" />
     </fragment>
     <fragment
         android:id="@+id/scheduleSelectFragment"
@@ -85,4 +88,8 @@
             android:id="@+id/action_recordViewOneFragment_to_recordViewManyFragment"
             app:destination="@id/recordViewManyFragment" />
     </fragment>
+    <fragment
+        android:id="@+id/placeSearchFragment"
+        android:name="com.thequietz.travelog.place.view.PlaceSearchFragment"
+        android:label="PlaceSearchFragment" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,5 +40,10 @@
 
     <string name="tv_noData">해당 데이터가 없습니다</string>
     <string name="tv_empty_result">여행지가 없습니다.</string>
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="tv_place_search_item">스타벅스</string>
+    <string name="btn_search_place">장소</string>
+    <string name="tv_google_map_view">구글 맵</string>
 
 </resources>


### PR DESCRIPTION
# #24 

## 작업 내용

- Retrofit으로 구글 맵 Web API 요청을 통해 검색어에 해당하는 데이터 출력
- 지도 화면은 우선 LinearLayout으로 대체
- RecyclerView, ListAdapter, DiffUtil로 장소 목록 렌더링
- RecyclerView에 Height 제한
- Adapter 내 인터페이스 정의한 뒤 해당 프래그먼트에서 장소 터치 리스너 함수를 인자로 전달
- 프래그먼트 내 뷰모델, 어댑터 내 모델 데이터 바인딩

## 메시지

작업할 때 커밋을 나눴어야 했는데 잊어버려서 작업한 거 통째로 커밋이 됐네요. 주의하겠습니다.