### PR TITLE
#44 [장소 정보 상세 화면] 리뷰 커스텀 뷰 및 구분선 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ plugins {
     id 'kotlin-parcelize'
 }
 
-Properties properties = new Properties()
-properties.load(project.rootProject.file("local.properties").newDataInputStream())
+// Properties properties = new Properties()
+// properties.load(project.rootProject.file("local.properties").newDataInputStream())
 
 android {
     compileSdk 31
@@ -21,7 +21,7 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField "String", "GOOGLE_MAP_KEY", properties["google_map_key"]
+        // buildConfigField "String", "GOOGLE_MAP_KEY", properties["google_map_key"]
         // buildConfigField "String", "TOUR_API_KEY", properties["tour_api_key"]
     }
 

--- a/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceDetailAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceDetailAdapter.kt
@@ -7,7 +7,6 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
-import com.thequietz.travelog.BuildConfig
 import com.thequietz.travelog.R
 import com.thequietz.travelog.databinding.ItemRecyclerPlaceDetailBinding
 import com.thequietz.travelog.place.model.PlaceDetailPhoto
@@ -18,7 +17,7 @@ class PlaceDetailAdapter : ListAdapter<PlaceDetailPhoto, PlaceDetailAdapter.View
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(model: PlaceDetailPhoto) {
-            val apiKey = BuildConfig.GOOGLE_MAP_KEY
+            val apiKey = "" // BuildConfig.GOOGLE_MAP_KEY
             val imageUrl =
                 "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${model.photoId}&key=$apiKey"
             binding.model = model

--- a/app/src/main/java/com/thequietz/travelog/place/repository/PlaceDetailRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/repository/PlaceDetailRepository.kt
@@ -1,6 +1,5 @@
 package com.thequietz.travelog.place.repository
 
-import com.thequietz.travelog.BuildConfig
 import com.thequietz.travelog.api.PlaceSearchService
 import com.thequietz.travelog.place.model.PlaceDetailModel
 import kotlinx.coroutines.Dispatchers
@@ -14,7 +13,7 @@ class PlaceDetailRepository @Inject constructor(
 
     suspend fun loadPlaceDetail(placeId: String): PlaceDetailModel? {
         return withContext(Dispatchers.IO) {
-            val apiKey = BuildConfig.GOOGLE_MAP_KEY
+            val apiKey = "" // BuildConfig.GOOGLE_MAP_KEY
             val call = service.loadPlaceDetail(placeId, apiKey)
             val response = call.awaitResponse()
             if (!response.isSuccessful || response.body() == null) {

--- a/app/src/main/java/com/thequietz/travelog/place/repository/PlaceSearchRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/repository/PlaceSearchRepository.kt
@@ -1,6 +1,5 @@
 package com.thequietz.travelog.place.repository
 
-import com.thequietz.travelog.BuildConfig
 import com.thequietz.travelog.api.PlaceSearchService
 import com.thequietz.travelog.place.model.PlaceSearchModel
 import retrofit2.awaitResponse
@@ -10,7 +9,7 @@ class PlaceSearchRepository @Inject constructor(
     private val service: PlaceSearchService,
 ) {
     suspend fun loadPlaceList(query: String): List<PlaceSearchModel> {
-        val apiKey = BuildConfig.GOOGLE_MAP_KEY
+        val apiKey = "" // BuildConfig.GOOGLE_MAP_KEY
         val call = service.loadPlaceList(query, apiKey)
         val response = call.awaitResponse()
         if (!response.isSuccessful || response.body() == null) {

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceDetailFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceDetailFragment.kt
@@ -1,6 +1,7 @@
 package com.thequietz.travelog.place.view
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -55,6 +56,22 @@ class PlaceDetailFragment : Fragment() {
 
         viewModel.detail.observe(viewLifecycleOwner, {
             (binding.rvPlaceDetail.adapter as PlaceDetailAdapter).submitList(it.photos)
+            if (viewModel.isLoaded.value == false) {
+
+                val parentContext = requireContext()
+                it.reviews.forEachIndexed { idx, review ->
+                    Log.d("IS_LOADED", viewModel.isLoaded.value.toString())
+                    val reviewLayout = PlaceReviewLayout(
+                        parentContext,
+                        review
+                    )
+                    reviewLayout.id = idx * 31
+                    binding.llPlaceDetail.addView(
+                        reviewLayout
+                    )
+                }
+                viewModel.isLoaded.value = true
+            }
         })
         viewModel.loadPlaceDetail(model.placeId)
     }

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceDetailFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceDetailFragment.kt
@@ -57,7 +57,7 @@ class PlaceDetailFragment : Fragment() {
         viewModel.detail.observe(viewLifecycleOwner, {
             (binding.rvPlaceDetail.adapter as PlaceDetailAdapter).submitList(it.photos)
             if (viewModel.isLoaded.value == false) {
-
+                val len = it.reviews.size
                 val parentContext = requireContext()
                 it.reviews.forEachIndexed { idx, review ->
                     Log.d("IS_LOADED", viewModel.isLoaded.value.toString())
@@ -68,6 +68,12 @@ class PlaceDetailFragment : Fragment() {
                     reviewLayout.id = idx * 31
                     binding.llPlaceDetail.addView(
                         reviewLayout
+                    )
+                    if (idx == len - 1) {
+                        return@forEachIndexed
+                    }
+                    binding.llPlaceDetail.addView(
+                        PlaceReviewDividerLayout(parentContext)
                     )
                 }
                 viewModel.isLoaded.value = true

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceReviewDividerLayout.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceReviewDividerLayout.kt
@@ -1,0 +1,15 @@
+package com.thequietz.travelog.place.view
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.widget.LinearLayout
+import com.thequietz.travelog.R
+
+class PlaceReviewDividerLayout(_context: Context) : LinearLayout(_context) {
+
+    init {
+        val inflater: LayoutInflater =
+            context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+        inflater.inflate(R.layout.layout_review_divider, this, true)
+    }
+}

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceReviewLayout.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceReviewLayout.kt
@@ -1,0 +1,39 @@
+package com.thequietz.travelog.place.view
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.bumptech.glide.Glide
+import com.thequietz.travelog.R
+import com.thequietz.travelog.place.model.PlaceDetailReview
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class PlaceReviewLayout(_context: Context, review: PlaceDetailReview) :
+    ConstraintLayout(_context) {
+
+    init {
+        val inflater: LayoutInflater =
+            context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+        val v = inflater.inflate(R.layout.layout_place_review, this, true)
+        val converter = SimpleDateFormat("yyyy.MM.dd", Locale.KOREAN)
+
+        v.findViewById<TextView>(R.id.tv_item_place_review).text = review.author
+        v.findViewById<TextView>(R.id.tv_item_place_review_time).text =
+            converter.format(Date(review.time * 1000))
+        v.findViewById<TextView>(R.id.tv_item_place_review_text).text = review.text
+        v.findViewById<TextView>(R.id.tv_item_place_review_relative_time).text =
+            review.timeDescription
+        v.findViewById<TextView>(R.id.tv_item_place_review_rating).text = "⭐ ${review.rating}"
+
+        val imageView = v.findViewById<ImageView>(R.id.iv_item_place_review_profile)
+        Glide.with(imageView)
+            .load(review.authorImage)
+            .centerCrop()
+            .override(imageView.measuredWidth, imageView.measuredHeight)
+            .into(imageView)
+    }
+}

--- a/app/src/main/java/com/thequietz/travelog/place/viewmodel/PlaceDetailViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/viewmodel/PlaceDetailViewModel.kt
@@ -10,7 +10,6 @@ import com.thequietz.travelog.place.repository.PlaceDetailRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
-import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
 
@@ -29,6 +28,8 @@ class PlaceDetailViewModel @Inject constructor(
     private var _review = MutableLiveData<String>()
     val review: LiveData<String> get() = _review
 
+    var isLoaded = MutableLiveData(false)
+
     fun loadPlaceDetail(placeId: String) {
         viewModelScope.launch {
             val data = repository.loadPlaceDetail(placeId)
@@ -41,9 +42,9 @@ class PlaceDetailViewModel @Inject constructor(
                 val newValue = acc + value + "\n"
                 newValue
             })
-            _review.value = data?.reviews?.fold("", { acc, value ->
+            /*_review.value = data?.reviews?.fold("", { acc, value ->
                 acc + value.text + "\n" + converter.format(Date(value.time * 1000)) + "\n\n"
-            })
+            })*/
         }
     }
 }

--- a/app/src/main/res/layout/fragment_place_detail.xml
+++ b/app/src/main/res/layout/fragment_place_detail.xml
@@ -41,7 +41,7 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintVertical_chainStyle="packed"
-                    app:layout_scrollFlags="scroll|enterAlways">
+                    app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
                     <TextView
                         android:layout_width="match_parent"
@@ -54,11 +54,18 @@
 
                 </LinearLayout>
 
+                <androidx.appcompat.widget.Toolbar
+                    android:layout_width="match_parent"
+                    android:layout_height="?attr/actionBarSize"
+                    app:layout_collapseMode="pin"
+                    app:title="@{viewModel.detail.name}" />
+
             </com.google.android.material.appbar.CollapsingToolbarLayout>
 
         </com.google.android.material.appbar.AppBarLayout>
 
         <androidx.core.widget.NestedScrollView
+            android:id="@+id/nv_place_detail"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="fill_vertical"
@@ -128,23 +135,6 @@
                     android:text="@{viewModel.operation}"
                     android:textSize="16sp"
                     tools:text="월요일: 오전 7:00 ~ 오후 7:00" />
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginVertical="8dp"
-                    android:text="@string/tv_place_detail_review"
-                    android:textSize="18sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/tv_place_detail_review"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:lineSpacingExtra="4sp"
-                    android:text="@{viewModel.review}"
-                    android:textSize="16sp"
-                    tools:text="@string/tv_place_detail_review_sample" />
 
                 <TextView
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/layout_place_review.xml
+++ b/app/src/main/res/layout/layout_place_review.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="20dp"
+    tools:context=".place.view.PlaceReviewLayout">
+
+    <TextView
+        android:id="@+id/tv_item_place_review"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:tag=""
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="@string/tv_place_review" />
+
+    <TextView
+        android:id="@+id/tv_item_place_review_relative_time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="@id/tv_item_place_review"
+        app:layout_constraintTop_toBottomOf="@id/tv_item_place_review"
+        tools:text="@string/tv_place_review_relative_time" />
+
+    <TextView
+        android:id="@+id/tv_item_place_review_rating"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="@id/tv_item_place_review_relative_time"
+        app:layout_constraintStart_toEndOf="@id/tv_item_place_review_relative_time"
+        app:layout_constraintTop_toTopOf="@id/tv_item_place_review_relative_time"
+        tools:text="⭐ 4" />
+
+    <ImageView
+        android:id="@+id/iv_item_place_review_profile"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
+        android:layout_marginTop="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@tools:sample/avatars" />
+
+    <TextView
+        android:id="@+id/tv_item_place_review_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        app:layout_constraintTop_toBottomOf="@id/tv_item_place_review_relative_time"
+        tools:text="@string/tv_place_detail_review_sample" />
+
+    <TextView
+        android:id="@+id/tv_item_place_review_time"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        app:layout_constraintTop_toBottomOf="@id/tv_item_place_review_text"
+        tools:text="@string/tv_item_place_review_time" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_review_divider.xml
+++ b/app/src/main/res/layout/layout_review_divider.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="1dp"
+    android:layout_marginVertical="6dp"
+    android:background="@color/black">
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,5 +57,9 @@
     <string name="tv_place_detail_review_sample">3층의 뷰~. 해변을 보면서 맛과 향이 좋은 콜롬비아 드립커피를 마시면 잠시 여유로움 속으로 행복이 스며듭니다</string>
     <string name="tv_place_detail_phone_title">전화번호</string>
     <string name="tv_place_detail_phone_number">033-653-0931</string>
+    <string name="tv_place_review">운영자</string>
+    <string name="tv_place_review_rating">5점</string>
+    <string name="tv_place_review_relative_time">4일 전</string>
+    <string name="tv_item_place_review_time">2021년 11월 15일</string>
 
 </resources>


### PR DESCRIPTION
# #44 

## 작업 내용
- 사용자 리뷰에 대한 커스텀 레이아웃 생성 및 상세 화면 프래그먼트에 한 번씩만 부착
- LinearLayout으로 커스텀 구분선 정의하여 상세 화면 프래그먼트에 부착함으로써 리뷰 커스텀 뷰 구분
  - 마지막 리뷰 레이아웃에는 구분선 부착하지 않음