### PR TITLE
#61 [장소 검색 화면] 추천 관광 사진 터치 후 상세 정보 화면 이동

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "GOOGLE_MAP_KEY", properties["google_map_key"]
-        // buildConfigField "String", "TOUR_API_KEY", properties["tour_api_key"]
+        buildConfigField "String", "TOUR_API_KEY", properties["tour_api_key"]
     }
 
     buildTypes {

--- a/app/src/main/java/com/thequietz/travelog/api/PlaceRecommendService.kt
+++ b/app/src/main/java/com/thequietz/travelog/api/PlaceRecommendService.kt
@@ -1,6 +1,8 @@
 package com.thequietz.travelog.api
 
 import com.thequietz.travelog.place.model.PlaceRecommendResponse
+import com.thequietz.travelog.place.model.detail.RecommendImageResponse
+import com.thequietz.travelog.place.model.detail.RecommendResponse
 import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -20,6 +22,31 @@ interface PlaceRecommendService {
         @Query("arrange") arrange: String = "Q",
         @Query("numOfRows") rows: Int = 20,
     ): Call<PlaceRecommendResponse>
+
+    @GET("openapi/service/rest/KorService/detailCommon")
+    fun loadPlaceInfo(
+        @Query("contentTypeId") typeId: Int,
+        @Query("contentId") id: Long,
+        @Query("ServiceKey") apiKey: String,
+        @Query("MobileOS") os: String = "AND",
+        @Query("MobileApp") appName: String = "Travelog",
+        @Query("_type") contentType: String = "json",
+        @Query("defaultYN") default: String = "Y",
+        @Query("addrinfoYN") address: String = "Y",
+        @Query("mapinfoYN") map: String = "Y",
+        @Query("overviewYN") overview: String = "Y"
+    ): Call<RecommendResponse>
+
+    @GET("openapi/service/rest/KorService/detailImage")
+    fun loadPlaceImages(
+        @Query("contentTypeId") typeId: Int,
+        @Query("contentId") id: Long,
+        @Query("ServiceKey") apiKey: String,
+        @Query("MobileOS") os: String = "AND",
+        @Query("MobileApp") appName: String = "Travelog",
+        @Query("_type") contentType: String = "json",
+        @Query("numOfRows") rows: Int = 25,
+    ): Call<RecommendImageResponse>
 
     companion object {
 

--- a/app/src/main/java/com/thequietz/travelog/api/PlaceSearchService.kt
+++ b/app/src/main/java/com/thequietz/travelog/api/PlaceSearchService.kt
@@ -1,7 +1,7 @@
 package com.thequietz.travelog.api
 
-import com.thequietz.travelog.place.model.PlaceDetailModelResponse
 import com.thequietz.travelog.place.model.PlaceSearchModelResponse
+import com.thequietz.travelog.place.model.detail.PlaceDetailModelResponse
 import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory

--- a/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceDetailAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceDetailAdapter.kt
@@ -7,20 +7,27 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.thequietz.travelog.BuildConfig
 import com.thequietz.travelog.R
 import com.thequietz.travelog.databinding.ItemRecyclerPlaceDetailBinding
-import com.thequietz.travelog.place.model.PlaceDetailPhoto
+import com.thequietz.travelog.place.model.detail.PlaceDetailImage
 
-class PlaceDetailAdapter : ListAdapter<PlaceDetailPhoto, PlaceDetailAdapter.ViewHolder>(diffUtil) {
+class PlaceDetailAdapter(private val isRecommended: Boolean) :
+    ListAdapter<PlaceDetailImage, PlaceDetailAdapter.ViewHolder>(
+        placeDetailDiffUtil
+    ) {
 
-    inner class ViewHolder(private val binding: ItemRecyclerPlaceDetailBinding) :
+    class ViewHolder(private val binding: ItemRecyclerPlaceDetailBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(model: PlaceDetailPhoto) {
-            val apiKey = "" // BuildConfig.GOOGLE_MAP_KEY
-            val imageUrl =
-                "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${model.photoId}&key=$apiKey"
-            binding.model = model
+        fun bind(model: PlaceDetailImage, isRecommended: Boolean) {
+            val imageUrl = if (isRecommended) {
+                model.imageUrl
+            } else {
+                val apiKey = BuildConfig.GOOGLE_MAP_KEY
+                "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${model.imageId}&key=$apiKey"
+            }
+            binding.imageId = model.imageId
             Glide.with(binding.root)
                 .load(imageUrl)
                 .centerCrop()
@@ -30,20 +37,6 @@ class PlaceDetailAdapter : ListAdapter<PlaceDetailPhoto, PlaceDetailAdapter.View
                 )
                 .into(binding.ivItemPlaceDetailPhoto)
             binding.executePendingBindings()
-        }
-    }
-
-    companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<PlaceDetailPhoto>() {
-            override fun areItemsTheSame(
-                oldItem: PlaceDetailPhoto,
-                newItem: PlaceDetailPhoto
-            ) = oldItem.photoId == newItem.photoId
-
-            override fun areContentsTheSame(
-                oldItem: PlaceDetailPhoto,
-                newItem: PlaceDetailPhoto
-            ) = oldItem == newItem
         }
     }
 
@@ -59,6 +52,18 @@ class PlaceDetailAdapter : ListAdapter<PlaceDetailPhoto, PlaceDetailAdapter.View
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(getItem(position), isRecommended)
     }
+}
+
+private val placeDetailDiffUtil = object : DiffUtil.ItemCallback<PlaceDetailImage>() {
+    override fun areItemsTheSame(
+        oldItem: PlaceDetailImage,
+        newItem: PlaceDetailImage
+    ) = oldItem.imageId == newItem.imageId
+
+    override fun areContentsTheSame(
+        oldItem: PlaceDetailImage,
+        newItem: PlaceDetailImage
+    ) = oldItem == newItem
 }

--- a/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceRecommendAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceRecommendAdapter.kt
@@ -3,6 +3,7 @@ package com.thequietz.travelog.place.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -11,14 +12,14 @@ import com.thequietz.travelog.databinding.ItemRecyclerPlaceRecommendBinding
 import com.thequietz.travelog.place.model.PlaceRecommendModel
 import com.thequietz.travelog.place.model.PlaceRecommendWithList
 
-class PlaceRecommendAdapter :
+class PlaceRecommendAdapter(private val parentFragment: Fragment) :
     ListAdapter<PlaceRecommendWithList, PlaceRecommendAdapter.ViewHolder>(PlaceRecommendDiffUtil()) {
     class ViewHolder(private val binding: ItemRecyclerPlaceRecommendBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(title: String, data: List<PlaceRecommendModel>?) {
+        fun bind(title: String, data: List<PlaceRecommendModel>?, fragment: Fragment) {
             binding.tvPlaceRecommend.text = title
-            binding.rvPlaceRecommend.adapter = PlaceRecommendSpecAdapter()
+            binding.rvPlaceRecommend.adapter = PlaceRecommendSpecAdapter(fragment)
 
             (binding.rvPlaceRecommend.adapter as PlaceRecommendSpecAdapter).submitList(data)
             binding.executePendingBindings()
@@ -38,7 +39,7 @@ class PlaceRecommendAdapter :
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = getItem(position)
-        holder.bind(item.title, item.list.value)
+        holder.bind(item.title, item.list.value, parentFragment)
     }
 }
 

--- a/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceRecommendSpecAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceRecommendSpecAdapter.kt
@@ -3,21 +3,30 @@ package com.thequietz.travelog.place.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.google.gson.Gson
 import com.thequietz.travelog.R
 import com.thequietz.travelog.databinding.ItemRecyclerPlaceRecommendSpecBinding
 import com.thequietz.travelog.place.model.PlaceRecommendModel
+import com.thequietz.travelog.place.view.PlaceRecommendFragmentDirections
 
-class PlaceRecommendSpecAdapter :
+class PlaceRecommendSpecAdapter(private val parentFragment: Fragment) :
     ListAdapter<PlaceRecommendModel, PlaceRecommendSpecAdapter.ViewHolder>(
         PlaceRecommendSpecDiffUtil()
     ) {
-    class ViewHolder(private val binding: ItemRecyclerPlaceRecommendSpecBinding) :
+    private val gson = Gson()
+
+    class ViewHolder(
+        private val binding: ItemRecyclerPlaceRecommendSpecBinding,
+        private val gson: Gson
+    ) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(model: PlaceRecommendModel) {
+        fun bind(model: PlaceRecommendModel, fragment: Fragment) {
             Glide.with(binding.ivPlaceRecommendSpec)
                 .load(model.imageUrl)
                 .centerCrop()
@@ -26,6 +35,15 @@ class PlaceRecommendSpecAdapter :
                     binding.ivPlaceRecommendSpec.measuredHeight
                 )
                 .into(binding.ivPlaceRecommendSpec)
+
+            binding.ivPlaceRecommendSpec.setOnClickListener {
+                val param = gson.toJson(model)
+                val action =
+                    PlaceRecommendFragmentDirections.actionPlaceRecommendFragmentToPlaceDetailFragment(
+                        param, true,
+                    )
+                fragment.findNavController().navigate(action)
+            }
             binding.executePendingBindings()
         }
     }
@@ -37,12 +55,12 @@ class PlaceRecommendSpecAdapter :
             parent,
             false
         )
-        val viewHolder = ViewHolder(binding)
+        val viewHolder = ViewHolder(binding, gson)
         return viewHolder
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(getItem(position), parentFragment)
     }
 }
 

--- a/app/src/main/java/com/thequietz/travelog/place/model/detail/PlaceRecommend.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/model/detail/PlaceRecommend.kt
@@ -1,0 +1,74 @@
+package com.thequietz.travelog.place.model.detail
+
+import com.google.gson.annotations.SerializedName
+
+data class RecommendResponse(
+    @SerializedName("response")
+    val response: RecommendBody
+)
+
+data class RecommendBody(
+    @SerializedName("body")
+    val body: RecommendItems
+)
+
+data class RecommendItems(
+    @SerializedName("items")
+    val items: RecommendItem
+)
+
+data class RecommendItem(
+    @SerializedName("item")
+    val info: RecommendInfo
+)
+
+data class RecommendInfo(
+    @SerializedName("addr1")
+    val address: String,
+
+    @SerializedName("mapy")
+    val latitude: Double,
+
+    @SerializedName("mapx")
+    val longitude: Double,
+
+    @SerializedName("tel")
+    val phoneNumber: String = "",
+
+    @SerializedName("title")
+    val name: String,
+
+    @SerializedName("overview")
+    val overview: String = "",
+
+    @SerializedName("homepage")
+    val url: String,
+)
+
+data class RecommendImageResponse(
+    @SerializedName("response")
+    val response: RecommendImageBody
+)
+
+data class RecommendImageBody(
+    @SerializedName("body")
+    val body: RecommendImageItems
+)
+
+data class RecommendImageItems(
+    @SerializedName("items")
+    val items: RecommendImageItem
+)
+
+data class RecommendImageItem(
+    @SerializedName("item")
+    val images: List<RecommendImage> = listOf()
+)
+
+data class RecommendImage(
+    @SerializedName("originimgurl")
+    val imageUrl: String,
+
+    @SerializedName("serialnum")
+    val imageId: String,
+)

--- a/app/src/main/java/com/thequietz/travelog/place/model/detail/PlaceSearch.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/model/detail/PlaceSearch.kt
@@ -1,10 +1,12 @@
-package com.thequietz.travelog.place.model
+package com.thequietz.travelog.place.model.detail
 
 import com.google.gson.annotations.SerializedName
 
-data class PlaceDetailPhoto(
+data class PlaceDetailImage(
     @SerializedName("photo_reference")
-    val photoId: String,
+    val imageId: String,
+
+    val imageUrl: String = "",
 )
 
 data class PlaceDetailReview(
@@ -63,16 +65,18 @@ data class PlaceDetailModel(
     val geometry: PlaceDetailGeometry,
 
     @SerializedName("photos")
-    val photos: List<PlaceDetailPhoto>,
+    val images: List<PlaceDetailImage>,
 
     @SerializedName("reviews")
-    val reviews: List<PlaceDetailReview>,
+    val reviews: List<PlaceDetailReview>?,
 
     @SerializedName("types")
     val types: List<String>,
 
     @SerializedName("website")
     val website: String,
+
+    val overview: String? = ""
 )
 
 data class PlaceDetailModelResponse(

--- a/app/src/main/java/com/thequietz/travelog/place/repository/PlaceDetailRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/repository/PlaceDetailRepository.kt
@@ -1,27 +1,67 @@
 package com.thequietz.travelog.place.repository
 
+import android.util.Log
 import com.thequietz.travelog.BuildConfig
+import com.thequietz.travelog.api.PlaceRecommendService
 import com.thequietz.travelog.api.PlaceSearchService
-import com.thequietz.travelog.place.model.PlaceDetailModel
+import com.thequietz.travelog.place.model.detail.PlaceDetailModel
+import com.thequietz.travelog.place.model.detail.RecommendImage
+import com.thequietz.travelog.place.model.detail.RecommendInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.ResponseBody
 import retrofit2.awaitResponse
+import java.lang.Exception
 import javax.inject.Inject
 
 class PlaceDetailRepository @Inject constructor(
-    private val service: PlaceSearchService
+    private val searchService: PlaceSearchService,
+    private val recommendService: PlaceRecommendService,
 ) {
+
+    private fun logIfError(msg: ResponseBody?) =
+        Log.e("PLACE_DETAIL_REPOSITORY", msg.toString())
 
     suspend fun loadPlaceDetail(placeId: String): PlaceDetailModel? {
         return withContext(Dispatchers.IO) {
             val apiKey = BuildConfig.GOOGLE_MAP_KEY
-            val call = service.loadPlaceDetail(placeId, apiKey)
+            val call = searchService.loadPlaceDetail(placeId, apiKey)
             val response = call.awaitResponse()
             if (!response.isSuccessful || response.body() == null) {
+                logIfError(response.errorBody())
                 null
             }
-
             response.body()?.result
+        }
+    }
+
+    suspend fun loadPlaceInfo(typeId: Int, id: Long): RecommendInfo? {
+        return withContext(Dispatchers.IO) {
+            val apiKey = BuildConfig.TOUR_API_KEY
+            val call = recommendService.loadPlaceInfo(typeId, id, apiKey)
+            val response = call.awaitResponse()
+            if (!response.isSuccessful || response.body() == null) {
+                logIfError(response.errorBody())
+                null
+            }
+            response.body()?.response?.body?.items?.info
+        }
+    }
+
+    suspend fun loadPlaceImages(typeId: Int, id: Long): List<RecommendImage>? {
+        return withContext(Dispatchers.IO) {
+            try {
+                val apiKey = BuildConfig.TOUR_API_KEY
+                val call = recommendService.loadPlaceImages(typeId, id, apiKey)
+                val response = call.awaitResponse()
+                if (!response.isSuccessful || response.body() == null) {
+                    logIfError(response.errorBody())
+                    null
+                }
+                response.body()?.response?.body?.items?.images
+            } catch (e: Exception) {
+                null
+            }
         }
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/place/repository/PlaceRecommendRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/repository/PlaceRecommendRepository.kt
@@ -1,5 +1,6 @@
 package com.thequietz.travelog.place.repository
 
+import com.thequietz.travelog.BuildConfig
 import com.thequietz.travelog.api.PlaceRecommendService
 import com.thequietz.travelog.place.model.PlaceRecommendModel
 import kotlinx.coroutines.Dispatchers
@@ -12,7 +13,7 @@ class PlaceRecommendRepository @Inject constructor(
 ) {
     suspend fun loadPlaceData(typeId: Int): List<PlaceRecommendModel> {
         return withContext(Dispatchers.IO) {
-            val apiKey = "" // BuildConfig.TOUR_API_KEY
+            val apiKey = BuildConfig.TOUR_API_KEY
             val call = service.loadRecommendPlace(typeId, apiKey)
             val resp = call.awaitResponse()
             if (!resp.isSuccessful || resp.body() == null) {

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceRecommendFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceRecommendFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.thequietz.travelog.R
 import com.thequietz.travelog.databinding.FragmentPlaceRecommendBinding
@@ -43,9 +44,15 @@ class PlaceRecommendFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         _context = requireContext()
 
+        binding.etPlaceRecommendSearch.setOnClickListener {
+            val action =
+                PlaceRecommendFragmentDirections.actionPlaceRecommendFragmentToPlaceSearchFragment()
+            view.findNavController().navigate(action)
+        }
+
         viewModel.dataList.observe(viewLifecycleOwner, {
             binding.lifecycleOwner = viewLifecycleOwner
-            binding.rvPlaceRecommend.adapter = PlaceRecommendAdapter()
+            binding.rvPlaceRecommend.adapter = PlaceRecommendAdapter(this)
             binding.rvPlaceRecommend.layoutManager = LinearLayoutManager(_context)
 
             (binding.rvPlaceRecommend.adapter as PlaceRecommendAdapter).submitList(it)

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceReviewLayout.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceReviewLayout.kt
@@ -7,7 +7,7 @@ import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.bumptech.glide.Glide
 import com.thequietz.travelog.R
-import com.thequietz.travelog.place.model.PlaceDetailReview
+import com.thequietz.travelog.place.model.detail.PlaceDetailReview
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
@@ -30,6 +31,7 @@ class PlaceSearchFragment : Fragment() {
     private lateinit var adapter: PlaceSearchAdapter
     private lateinit var _context: Context
     private lateinit var gson: Gson
+    private lateinit var inputManager: InputMethodManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -48,15 +50,17 @@ class PlaceSearchFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        _context = requireContext()
         gson = Gson()
+        _context = requireContext()
+        inputManager = _context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
 
         adapter = PlaceSearchAdapter(object : PlaceSearchAdapter.OnItemClickListener {
             override fun onClickItem(model: PlaceSearchModel, position: Int): Boolean {
                 val param = gson.toJson(model)
                 val action =
                     PlaceSearchFragmentDirections.actionPlaceSearchFragmentToPlaceDetailFragment(
-                        param
+                        param,
+                        false,
                     )
                 view.findNavController().navigate(action)
                 return true
@@ -83,6 +87,7 @@ class PlaceSearchFragment : Fragment() {
             (binding.rvPlaceSearch.adapter as PlaceSearchAdapter).submitList(it)
         })
 
+        binding.etPlaceSearch.requestFocus()
         viewModel.initPlaceList()
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/place/viewmodel/PlaceDetailViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/viewmodel/PlaceDetailViewModel.kt
@@ -5,12 +5,14 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.thequietz.travelog.place.model.PlaceDetailModel
+import com.thequietz.travelog.place.model.detail.PlaceDetailGeometry
+import com.thequietz.travelog.place.model.detail.PlaceDetailImage
+import com.thequietz.travelog.place.model.detail.PlaceDetailLocation
+import com.thequietz.travelog.place.model.detail.PlaceDetailModel
+import com.thequietz.travelog.place.model.detail.PlaceDetailOperation
 import com.thequietz.travelog.place.repository.PlaceDetailRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
-import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -18,33 +20,64 @@ class PlaceDetailViewModel @Inject constructor(
     private val repository: PlaceDetailRepository
 ) : ViewModel() {
     private val TAG = "VIEWMODEL"
-    private val converter = SimpleDateFormat("yyyy.MM.dd", Locale.KOREAN)
+
+    private val typeMap = mapOf(
+        12 to "관광지",
+        14 to "문화시설",
+        15 to "행사 및 축제",
+        25 to "여행",
+        28 to "레포츠",
+        32 to "숙박시설",
+        38 to "쇼핑",
+        39 to "음식점",
+    )
+
     private var _detail = MutableLiveData<PlaceDetailModel>()
     val detail: LiveData<PlaceDetailModel> get() = _detail
 
     private var _operation = MutableLiveData<String>()
     val operation: LiveData<String> get() = _operation
 
-    private var _review = MutableLiveData<String>()
-    val review: LiveData<String> get() = _review
-
     var isLoaded = MutableLiveData(false)
 
-    fun loadPlaceDetail(placeId: String) {
+    fun loadDetailBySearch(placeId: String) {
         viewModelScope.launch {
             val data = repository.loadPlaceDetail(placeId)
+            Log.d(TAG, data.toString())
 
             data.let {
-                Log.d(TAG, it?.photos?.size.toString())
                 _detail.value = it
             }
             _operation.value = data?.operation?.operation?.fold("", { acc, value ->
                 val newValue = acc + value + "\n"
                 newValue
             })
-            /*_review.value = data?.reviews?.fold("", { acc, value ->
-                acc + value.text + "\n" + converter.format(Date(value.time * 1000)) + "\n\n"
-            })*/
+        }
+    }
+
+    fun loadDetailByRecommend(id: Long, typeId: Int) {
+        Log.d(TAG, "Detail Data Loaded")
+        viewModelScope.launch {
+            val images = repository.loadPlaceImages(typeId, id)
+            val info = repository.loadPlaceInfo(typeId, id)
+            _detail.value = PlaceDetailModel(
+                placeId = id.toString(),
+                address = info?.address ?: "",
+                phoneNumber = info?.phoneNumber ?: "",
+                name = info?.name ?: "",
+                operation = PlaceDetailOperation(true, listOf()),
+                geometry = PlaceDetailGeometry(
+                    PlaceDetailLocation(
+                        info?.latitude ?: Double.NaN,
+                        info?.longitude ?: Double.NaN
+                    )
+                ),
+                images = images?.map { PlaceDetailImage(it.imageId, it.imageUrl) } ?: listOf(),
+                reviews = listOf(),
+                types = listOf(typeMap[typeId] ?: "Unknown"),
+                website = info?.url ?: "",
+                overview = info?.overview ?: ""
+            )
         }
     }
 }

--- a/app/src/main/res/layout/fragment_place_detail.xml
+++ b/app/src/main/res/layout/fragment_place_detail.xml
@@ -43,14 +43,14 @@
                     app:layout_constraintVertical_chainStyle="packed"
                     app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
-                    <TextView
+                    <!--<TextView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:gravity="center_horizontal"
                         android:text="@string/tv_google_map_view"
                         android:textColor="@color/black"
                         android:textSize="30sp"
-                        android:textStyle="bold" />
+                        android:textStyle="bold" />-->
 
                 </LinearLayout>
 
@@ -75,6 +75,7 @@
                 android:id="@+id/ll_place_detail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginBottom="30dp"
                 android:orientation="vertical"
                 android:paddingHorizontal="20dp"
                 android:paddingTop="10dp"
@@ -137,6 +138,7 @@
                     tools:text="월요일: 오전 7:00 ~ 오후 7:00" />
 
                 <TextView
+                    android:id="@+id/tv_place_detail_phone_title"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginVertical="8dp"
@@ -152,6 +154,15 @@
                     android:text="@{viewModel.detail.phoneNumber}"
                     android:textSize="16sp"
                     tools:text="@string/tv_place_detail_phone_number" />
+
+                <TextView
+                    android:id="@+id/tv_place_detail_overview"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginBottom="100dp"
+                    android:text="@{viewModel.detail.overview}"
+                    android:textSize="16sp" />
 
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_place_recommend.xml
+++ b/app/src/main/res/layout/fragment_place_recommend.xml
@@ -8,7 +8,7 @@
         android:layout_height="match_parent"
         tools:context=".place.view.PlaceRecommendFragment">
 
-        <EditText
+        <TextView
             android:id="@+id/et_place_recommend_search"
             android:layout_width="0dp"
             android:layout_height="40dp"
@@ -17,7 +17,6 @@
             android:background="@color/et_search"
             android:drawableEnd="@drawable/ic_search"
             android:importantForAutofill="no"
-            android:inputType="text"
             android:singleLine="true"
             app:layout_constraintBottom_toTopOf="@id/rv_place_recommend"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_recycler_place_detail.xml
+++ b/app/src/main/res/layout/item_recycler_place_detail.xml
@@ -5,8 +5,8 @@
     <data>
 
         <variable
-            name="model"
-            type="com.thequietz.travelog.place.model.PlaceDetailPhoto" />
+            name="imageId"
+            type="String" />
     </data>
 
     <ImageView
@@ -15,6 +15,6 @@
         android:layout_height="80dp"
         android:layout_marginEnd="10dp"
 
-        android:contentDescription="@{model.photoId}"
+        android:contentDescription="@{imageId}"
         tools:src="@tools:sample/avatars" />
 </layout>

--- a/app/src/main/res/layout/layout_place_review.xml
+++ b/app/src/main/res/layout/layout_place_review.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="20dp"
+    android:layout_marginVertical="16dp"
     tools:context=".place.view.PlaceReviewLayout">
 
     <TextView

--- a/app/src/main/res/navigation/schedule.xml
+++ b/app/src/main/res/navigation/schedule.xml
@@ -22,9 +22,6 @@
             android:id="@+id/action_schedulePlaceFragment_to_scheduleSelectFragment"
             app:destination="@id/scheduleSelectFragment" />
         <action
-            android:id="@+id/action_schedulePlaceFragment_to_placeSearchFragment"
-            app:destination="@id/placeSearchFragment" />
-        <action
             android:id="@+id/action_schedulePlaceFragment_to_placeRecommendFragment"
             app:destination="@id/placeRecommendFragment" />
     </fragment>
@@ -65,11 +62,17 @@
         <argument
             android:name="param"
             app:argType="string" />
+        <argument
+            android:name="isRecommended"
+            app:argType="boolean" />
     </fragment>
     <fragment
         android:id="@+id/placeRecommendFragment"
         android:name="com.thequietz.travelog.place.view.PlaceRecommendFragment"
         android:label="PlaceRecommendFragment" >
+        <action
+            android:id="@+id/action_placeRecommendFragment_to_placeDetailFragment"
+            app:destination="@id/placeDetailFragment" />
         <action
             android:id="@+id/action_placeRecommendFragment_to_placeSearchFragment"
             app:destination="@id/placeSearchFragment" />


### PR DESCRIPTION
# #61 

## 작업 내용
- 추천 관광 정보 클릭 시 해당 장소 상세 정보 화면 이동
  - 하나의 수직 리사이클러 뷰 내 여러 개의 수평 리사이클러 뷰가 존재
  - 네비게이션 컨트롤러(findNavController)를 사용하기 위해 Fragment를 어댑터에 전달
  - 상세 정보를 불러오는데 관광정보 API 사용
- 동일한 장소 상세 정보 화면을 사용하기 위해 데이터 구조 통합
  - 추천 관광 정보 화면을 터치했을 때 정보(detailCommon), 이미지 API(detailImage)를 각각 호출함으로써 RecommendInfo, RecommendImage 객체를 얻을 수 있음
  - 두 객체를 가공하여 장소 상세 정보 화면에서 사용되는 PlaceDetailModel 형태로 변환
- PlaceDetailModel 내 몇몇 속성을 Nullable로 재정의
- PlaceDetailModel 내 추천 관광지 소개 글을 담을 수 있게 overview 속성을 Nullable 문자열로 정의

## 메시지
커밋 메시지를 #61로 올렸어야 했는데 타이핑 실수로 메시지가 $61로 입력되었습니다. 

관광 정보에서 관광지에 대한 이미지들을 불러올 수 있는 API가 제공되는데 이미지가 없으면 배열 형태가 아닌 문자열 형태가 와서 처리하는데 시간이 많이 걸렸습니다.