### PR TITLE
Hotfix [Fix] 여행 지역 선택 화면, 세부 일정 설정 화면 등

### DIFF
--- a/app/src/main/java/com/thequietz/travelog/api/GuideRecommendService.kt
+++ b/app/src/main/java/com/thequietz/travelog/api/GuideRecommendService.kt
@@ -6,23 +6,29 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Query
 
-const val SERVICE_KEY =
-    "nCt96vygV7qQ2zPRVStQfojU6mqUXNHBQbnUhOIlRuPoc5xiVQXTzspBS9GGS8sv3yKlcY7SY6HJYJ4SFruRtA%3D%3D"
-const val NEW_SERVICE_KEY =
-    "I2sJCPNlcsGIrgvauH84inSBsYebWCZnQpOVmzsR0bn%2B%2BuxZH%2Fqvq91QvQ02xehxqC6OBdprA1b0CVkrGxjOWw%3D%3D"
-
-interface PlaceRecommend {
-    @GET("/openapi/service/rest/KorService/areaBasedList?ServiceKey=$NEW_SERVICE_KEY&contentTypeId=15&MobileOS=AND&MobileApp=Travlelog&_type=json&arrange=P")
+interface GuideRecommendService {
+    @GET("/openapi/service/rest/KorService/areaBasedList")
     suspend fun requestRecommendPlace(
         @Query("areaCode") area: String,
-        @Query("sigunguCode") sigunguCode: String
+        @Query("sigunguCode") secondCode: String,
+        @Query("ServiceKey") key: String,
+        @Query("contentTypeId") typeId: Int = 15,
+        @Query("MobileOS") os: String = "AND",
+        @Query("MobileApp") appName: String = "Travelog",
+        @Query("_type") contentType: String = "json",
+        @Query("arrange") arrange: String = "P",
     ): RecommendResponse
 
-    @GET("/openapi/service/rest/KorService/areaBasedList?ServiceKey=$NEW_SERVICE_KEY&MobileOS=AND&MobileApp=Travlelog&_type=json&arrange=P")
+    @GET("/openapi/service/rest/KorService/areaBasedList")
     suspend fun requestAreaBased(
+        @Query("ServiceKey") key: String,
         @Query("areaCode") code: String,
         @Query("cat1") category: String,
-        @Query("pageNo") pageNo: Int
+        @Query("pageNo") pageNo: Int,
+        @Query("MobileOS") os: String = "AND",
+        @Query("MobileApp") appName: String = "Travelog",
+        @Query("_type") contentType: String = "json",
+        @Query("arrange") arrange: String = "P",
     ): RecommendResponse
 
     /* @GET("/openapi/service/rest/KorService/areaBasedList?ServiceKey=$SERVICE_KEY&MobileOS=AND&MobileApp=Travlelog&cat1=A01&_type=json&arrange=P")
@@ -34,23 +40,28 @@ interface PlaceRecommend {
      @GET("/openapi/service/rest/KorService/areaBasedList?ServiceKey=$SERVICE_KEY&MobileOS=AND&MobileApp=Travlelog&cat1=A05&_type=json&arrange=P")
      suspend fun requestFood(@Query("areaCode") code: String): RecommendResponse*/
 
-    @GET("/openapi/service/rest/KorService/searchFestival?ServiceKey=$NEW_SERVICE_KEY&MobileOS=ETC&MobileApp=Travlelog&_type=json&arrange=P")
+    @GET("/openapi/service/rest/KorService/searchFestival")
     suspend fun requestFestival(
+        @Query("ServiceKey") key: String,
         @Query("eventStartDate") startDate: String,
         @Query("areaCode") code: String,
-        @Query("pageNo") pageNo: Int
+        @Query("pageNo") pageNo: Int,
+        @Query("MobileOS") os: String = "AND",
+        @Query("MobileApp") appName: String = "Travelog",
+        @Query("_type") contentType: String = "json",
+        @Query("arrange") arrange: String = "P",
     ): RecommendResponse
 
     companion object {
         private const val apiUrl = "http://api.visitkorea.or.kr"
 
-        fun create(): PlaceRecommend {
+        fun create(): GuideRecommendService {
             return Retrofit
                 .Builder()
                 .baseUrl(apiUrl)
                 .addConverterFactory(GsonConverterFactory.create())
                 .build()
-                .create(PlaceRecommend::class.java)
+                .create(GuideRecommendService::class.java)
         }
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/data/Repository.kt
+++ b/app/src/main/java/com/thequietz/travelog/data/Repository.kt
@@ -1,7 +1,8 @@
 package com.thequietz.travelog.data
 
 import android.util.Log
-import com.thequietz.travelog.api.PlaceRecommend
+import com.thequietz.travelog.BuildConfig
+import com.thequietz.travelog.api.GuideRecommendService
 import com.thequietz.travelog.api.PlaceService
 import com.thequietz.travelog.data.db.dao.RecordImageDao
 import com.thequietz.travelog.data.db.dao.ScheduleDao
@@ -18,8 +19,10 @@ import javax.inject.Singleton
 @Singleton
 class GuideRepository @Inject constructor(
     private val placeService: PlaceService,
-    private val placeRecommend: PlaceRecommend
+    private val guideRecommendService: GuideRecommendService
 ) {
+
+    private val TOUR_API_KEY = BuildConfig.TOUR_API_KEY
 
     suspend fun loadAllPlaceData(): List<Place> {
         val result = placeService.requestAll()
@@ -42,13 +45,13 @@ class GuideRepository @Inject constructor(
     }
 
     suspend fun loadRecommendPlaceData(areaCode: String = "1", sigunguCode: String = "10"): List<RecommendPlace> {
-        val res = placeRecommend.requestRecommendPlace(areaCode, sigunguCode).response.body.items.item
+        val res = guideRecommendService.requestRecommendPlace(areaCode, sigunguCode, TOUR_API_KEY).response.body.items.item
         return res
     }
 
     suspend fun loadAreaData(areaCode: String = "1", requestType: String = "A01", pageNo: Int): List<RecommendPlace> {
         return try {
-            val res = placeRecommend.requestAreaBased(areaCode, requestType, pageNo)
+            val res = guideRecommendService.requestAreaBased(TOUR_API_KEY, areaCode, requestType, pageNo)
             val maxPage = (res.response.body.totalCnt / 10) + 1
             if (maxPage < pageNo) {
                 return listOf()
@@ -71,7 +74,7 @@ class GuideRepository @Inject constructor(
 */
     suspend fun loadFestivalData(areaCode: String, pageNo: Int): List<RecommendPlace> {
         return try {
-            val res = placeRecommend.requestFestival(getTodayDate(), areaCode, pageNo)
+            val res = guideRecommendService.requestFestival(TOUR_API_KEY, getTodayDate(), areaCode, pageNo)
             val maxPage = (res.response.body.totalCnt / 10) + 1
             if (maxPage < pageNo) {
                 return listOf()

--- a/app/src/main/java/com/thequietz/travelog/di/NetworkModule.kt
+++ b/app/src/main/java/com/thequietz/travelog/di/NetworkModule.kt
@@ -1,6 +1,6 @@
 package com.thequietz.travelog.di
 
-import com.thequietz.travelog.api.PlaceRecommend
+import com.thequietz.travelog.api.GuideRecommendService
 import com.thequietz.travelog.api.PlaceRecommendService
 import com.thequietz.travelog.api.PlaceSearchService
 import com.thequietz.travelog.api.PlaceService
@@ -16,8 +16,8 @@ object NetworkModule {
 
     @Singleton
     @Provides
-    fun providePlaceRecommend(): PlaceRecommend {
-        return PlaceRecommend.create()
+    fun providePlaceRecommend(): GuideRecommendService {
+        return GuideRecommendService.create()
     }
 
     @Singleton

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceRecommendFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceRecommendFragment.kt
@@ -9,10 +9,12 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.findNavController
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.thequietz.travelog.R
 import com.thequietz.travelog.databinding.FragmentPlaceRecommendBinding
 import com.thequietz.travelog.place.adapter.PlaceRecommendAdapter
+import com.thequietz.travelog.place.model.PlaceDetailModel
 import com.thequietz.travelog.place.viewmodel.PlaceRecommendViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -43,6 +45,17 @@ class PlaceRecommendFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _context = requireContext()
+
+        findNavController().apply {
+            currentBackStackEntry?.savedStateHandle
+                ?.getLiveData<PlaceDetailModel>("result")?.observe(
+                    viewLifecycleOwner,
+                    {
+                        previousBackStackEntry?.savedStateHandle?.set("result", it)
+                        popBackStack()
+                    }
+                )
+        }
 
         binding.etPlaceRecommendSearch.setOnClickListener {
             val action =

--- a/app/src/main/java/com/thequietz/travelog/schedule/view/ScheduleDetailFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/view/ScheduleDetailFragment.kt
@@ -36,29 +36,31 @@ class ScheduleDetailFragment :
             }
         }
 
-        findNavController().currentBackStackEntry?.savedStateHandle
-            ?.getLiveData<PlaceDetailModel>("result")?.observe(
-                viewLifecycleOwner,
-                {
-                    viewModel.addSchedule(it)
+        val stateHandle = findNavController().currentBackStackEntry?.savedStateHandle
 
-                    val newTarget =
-                        LatLng(it.geometry.location.latitude, it.geometry.location.longitude)
+        stateHandle?.getLiveData<PlaceDetailModel>("result")?.observe(
+            viewLifecycleOwner,
+            {
+                viewModel.addSchedule(it)
 
-                    if (viewModel.placeDetailList.value?.size ?: 0 < 2)
-                        targetList.value = mutableListOf(newTarget)
-                    else
-                        targetList.value = targetList.value.apply {
-                            this?.add(newTarget)
-                        }
+                val newTarget =
+                    LatLng(it.geometry.location.latitude, it.geometry.location.longitude)
 
-                    createMarker(newTarget, isNumbered = true)
-                    markerList.forEachIndexed { index, marker ->
-                        if (index + 1 < markerList.size)
-                            createPolyline(marker, markerList[index + 1])
+                if (viewModel.placeDetailList.value?.size ?: 0 < 2)
+                    targetList.value = mutableListOf(newTarget)
+                else
+                    targetList.value = targetList.value.apply {
+                        this?.add(newTarget)
                     }
+
+                createMarker(newTarget, isNumbered = true)
+                markerList.forEachIndexed { index, marker ->
+                    if (index + 1 < markerList.size)
+                        createPolyline(marker, markerList[index + 1])
                 }
-            )
+                stateHandle.remove<PlaceDetailModel>("result")
+            }
+        )
     }
 
     override fun initViewModel() {
@@ -73,7 +75,7 @@ class ScheduleDetailFragment :
         viewModel.initItemList(startDate, endDate)
         adapter = ScheduleDetailAdapter(viewModel) {
             val action =
-                ScheduleDetailFragmentDirections.actionScheduleDetailFragmentToPlaceSearchFragment()
+                ScheduleDetailFragmentDirections.actionScheduleDetailFragmentToPlaceRecommendFragment()
             this.findNavController().navigate(action)
         }
         val callback = ScheduleTouchHelperCallback(adapter)

--- a/app/src/main/java/com/thequietz/travelog/schedule/view/SchedulePlaceFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/view/SchedulePlaceFragment.kt
@@ -80,17 +80,11 @@ class SchedulePlaceFragment : Fragment() {
         }
 
         binding.btnSelectDate.setOnClickListener {
-            val placeList = viewModel.selectedPlaces.value
+            val placeList = viewModel.placeSelectedList.value
             val action =
                 SchedulePlaceFragmentDirections.actionSchedulePlaceFragmentToScheduleSelectFragment(
                     placeList?.toTypedArray() ?: arrayOf()
                 )
-            it.findNavController().navigate(action)
-        }
-
-        binding.btnSearchPlace.setOnClickListener {
-            val action =
-                SchedulePlaceFragmentDirections.actionSchedulePlaceFragmentToPlaceRecommendFragment()
             it.findNavController().navigate(action)
         }
 

--- a/app/src/main/java/com/thequietz/travelog/schedule/viewmodel/SchedulePlaceViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/viewmodel/SchedulePlaceViewModel.kt
@@ -17,8 +17,8 @@ class SchedulePlaceViewModel @Inject constructor(
     private var _placeList = MutableLiveData<List<PlaceModel>>()
     val placeList: LiveData<List<PlaceModel>> = _placeList
 
-    private var _selectedPlaces = MutableLiveData<MutableList<PlaceModel>>()
-    val selectedPlaces: LiveData<MutableList<PlaceModel>> = _selectedPlaces
+    /*private var _selectedPlaces = MutableLiveData<MutableList<PlaceModel>>()
+    val selectedPlaces: LiveData<MutableList<PlaceModel>> = _selectedPlaces*/
 
     private var _placeSelectedList = MutableLiveData<MutableList<PlaceModel>>()
     val placeSelectedList: LiveData<MutableList<PlaceModel>> = _placeSelectedList
@@ -37,7 +37,6 @@ class SchedulePlaceViewModel @Inject constructor(
 
     fun initPlaceSelectedList() {
         _placeSelectedList.value = mutableListOf()
-        _selectedPlaces.value = mutableListOf()
     }
 
     fun addPlaceSelectedList(value: PlaceModel) {
@@ -46,8 +45,6 @@ class SchedulePlaceViewModel @Inject constructor(
 
         _placeSelectedList.value?.add(value)
         _placeSelectedList.value = _placeSelectedList.value
-        _selectedPlaces.value?.add(value)
-        _selectedPlaces.value = _selectedPlaces.value
     }
 
     fun removePlaceSelectedList(cityName: String) {

--- a/app/src/main/res/layout/fragment_schedule_place.xml
+++ b/app/src/main/res/layout/fragment_schedule_place.xml
@@ -35,21 +35,8 @@
             android:layout_marginStart="10dp"
             android:text="@string/btn_search"
             app:layout_constraintBottom_toBottomOf="@id/et_search"
-            app:layout_constraintEnd_toEndOf="@id/btn_search_place"
-            app:layout_constraintStart_toEndOf="@id/et_search"
-            app:layout_constraintTop_toTopOf="@id/et_search" />
-
-        <Button
-            android:id="@+id/btn_search_place"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="4dp"
-            android:minWidth="0dp"
-            android:paddingHorizontal="12dp"
-            android:text="@string/btn_search_place"
-            app:layout_constraintBottom_toBottomOf="@id/et_search"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/btn_select_date"
+            app:layout_constraintStart_toEndOf="@id/et_search"
             app:layout_constraintTop_toTopOf="@id/et_search" />
 
         <TextView

--- a/app/src/main/res/navigation/schedule.xml
+++ b/app/src/main/res/navigation/schedule.xml
@@ -24,9 +24,6 @@
         <action
             android:id="@+id/action_schedulePlaceFragment_to_scheduleSelectFragment"
             app:destination="@id/scheduleSelectFragment" />
-        <action
-            android:id="@+id/action_schedulePlaceFragment_to_placeRecommendFragment"
-            app:destination="@id/placeRecommendFragment" />
     </fragment>
     <fragment
         android:id="@+id/scheduleSelectFragment"
@@ -47,13 +44,13 @@
             android:name="schedule"
             app:argType="com.thequietz.travelog.schedule.model.ScheduleModel" />
         <action
-            android:id="@+id/action_scheduleDetailFragment_to_placeSearchFragment"
-            app:destination="@id/placeSearchFragment" />
-        <action
             android:id="@+id/action_scheduleDetailFragment_to_scheduleFragment"
             app:destination="@id/scheduleFragment"
             app:popUpTo="@id/scheduleFragment"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_scheduleDetailFragment_to_placeRecommendFragment"
+            app:destination="@id/placeRecommendFragment" />
     </fragment>
     <fragment
         android:id="@+id/placeSearchFragment"


### PR DESCRIPTION
# 작업 내용

- 여행 지역 선택 화면
  - 임시로 생성해 둔 "장소" 버튼 삭제
  - 검색을 클릭하면 우선 추천 관광지 목록을 출력
  - 상단 검색 창을 클릭하면 검색 화면으로 이동

- 세부 일정 설정 화면
  - 여행 지역 추가 후 백스택의 LiveData를 검사하여 "result" 키에 해당하는 데이터 제거
  - 여행 데이터가 중복되는 것을 방지

- 장소 검색 화면
  - 추천 관광지를 보여주는 화면에서 popBackstack 동작 하나 더 추가