### PR TITLE
#75 [여행 지역 선택 화면] 리사이클러 뷰 위치 유지 & 에러 처리 통일

### DIFF
--- a/app/src/main/java/com/thequietz/travelog/data/Repository.kt
+++ b/app/src/main/java/com/thequietz/travelog/data/Repository.kt
@@ -14,7 +14,6 @@ import com.thequietz.travelog.record.model.RecordImage
 import com.thequietz.travelog.schedule.model.ScheduleModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import retrofit2.HttpException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -23,30 +22,33 @@ class GuideRepository @Inject constructor(
     private val placeService: PlaceService,
     private val guideRecommendService: GuideRecommendService
 ) {
-
+    private val TAG = "GUIDE"
     private val TOUR_API_KEY = BuildConfig.TOUR_API_KEY
     private val NEW_TOUR_API_KEY = BuildConfig.NEW_TOUR_API_KEY
 
-    suspend fun loadAllPlaceData(): List<Place> {
-        val result = try {
-            placeService.requestAll().data
-        } catch (e: HttpException) {
-            listOf()
-        } catch (e: JsonSyntaxException) {
-            listOf()
-        }
+    private val emptyList = emptyList<Place>()
+    private val emptyRecommendList = emptyList<RecommendPlace>()
 
-        return result
+    suspend fun loadAllPlaceData(): List<Place> {
+        return try {
+            placeService.requestAll().data
+        } catch (e: JsonSyntaxException) {
+            emptyList
+        } catch (t: Throwable) {
+            Log.d(TAG, t.stackTraceToString())
+            emptyList
+        }
     }
 
     suspend fun loadAllDoSi(): List<Place> {
         return try {
             val result = placeService.requestALLDoSi()
             result.data
-        } catch (e: HttpException) {
-            listOf()
         } catch (e: JsonSyntaxException) {
-            listOf()
+            emptyList
+        } catch (t: Throwable) {
+            Log.d(TAG, t.stackTraceToString())
+            emptyList
         }
     }
 
@@ -54,10 +56,11 @@ class GuideRepository @Inject constructor(
         return try {
             val result = placeService.requestDoSiByCode(code)
             result.data
-        } catch (e: HttpException) {
-            listOf()
         } catch (e: JsonSyntaxException) {
-            listOf()
+            emptyList
+        } catch (t: Throwable) {
+            Log.d(TAG, t.stackTraceToString())
+            emptyList
         }
     }
 
@@ -65,10 +68,11 @@ class GuideRepository @Inject constructor(
         return try {
             val result = placeService.requestAllByKeyword(keyword)
             result.data
-        } catch (e: HttpException) {
-            listOf()
         } catch (e: JsonSyntaxException) {
-            listOf()
+            emptyList
+        } catch (t: Throwable) {
+            Log.d(TAG, t.stackTraceToString())
+            emptyList
         }
     }
 
@@ -83,10 +87,11 @@ class GuideRepository @Inject constructor(
                 NEW_TOUR_API_KEY
             ).response.body.items.item
             res
-        } catch (e: HttpException) {
-            listOf()
         } catch (e: JsonSyntaxException) {
-            listOf()
+            emptyRecommendList
+        } catch (t: Throwable) {
+            Log.d(TAG, t.stackTraceToString())
+            emptyRecommendList
         }
     }
 
@@ -96,17 +101,23 @@ class GuideRepository @Inject constructor(
         pageNo: Int
     ): List<RecommendPlace> {
         return try {
-            val res = guideRecommendService.requestAreaBased(NEW_TOUR_API_KEY, areaCode, requestType, pageNo)
+            val res = guideRecommendService.requestAreaBased(
+                NEW_TOUR_API_KEY,
+                areaCode,
+                requestType,
+                pageNo
+            )
             val maxPage = (res.response.body.totalCnt / 10) + 1
             if (maxPage < pageNo) {
-                return listOf()
+                emptyRecommendList
             } else {
-                return res.response.body.items.item
+                res.response.body.items.item
             }
-        } catch (e: Exception) {
-            listOf()
         } catch (e: JsonSyntaxException) {
-            listOf()
+            emptyRecommendList
+        } catch (t: Throwable) {
+            Log.d(TAG, t.stackTraceToString())
+            emptyRecommendList
         }
     }
 
@@ -122,17 +133,23 @@ class GuideRepository @Inject constructor(
 */
     suspend fun loadFestivalData(areaCode: String, pageNo: Int): List<RecommendPlace> {
         return try {
-            val res = guideRecommendService.requestFestival(NEW_TOUR_API_KEY, getTodayDate(), areaCode, pageNo)
+            val res = guideRecommendService.requestFestival(
+                NEW_TOUR_API_KEY,
+                getTodayDate(),
+                areaCode,
+                pageNo
+            )
             val maxPage = (res.response.body.totalCnt / 10) + 1
             if (maxPage < pageNo) {
-                return listOf()
+                emptyRecommendList
             } else {
-                return res.response.body.items.item
+                res.response.body.items.item
             }
-        } catch (e: Exception) {
-            listOf()
         } catch (e: JsonSyntaxException) {
-            listOf()
+            emptyRecommendList
+        } catch (t: Throwable) {
+            Log.d(TAG, t.stackTraceToString())
+            emptyRecommendList
         }
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/place/repository/PlaceRecommendRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/repository/PlaceRecommendRepository.kt
@@ -6,7 +6,6 @@ import com.thequietz.travelog.api.PlaceRecommendService
 import com.thequietz.travelog.place.model.PlaceRecommendModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import retrofit2.HttpException
 import retrofit2.awaitResponse
 import java.net.SocketTimeoutException
 import javax.inject.Inject
@@ -15,6 +14,7 @@ class PlaceRecommendRepository @Inject constructor(
     private val service: PlaceRecommendService,
 ) {
     private val TAG = "PLACE_RECOMMEND"
+    private var emptyList = emptyList<PlaceRecommendModel>()
 
     suspend fun loadPlaceData(typeId: Int): List<PlaceRecommendModel> {
         return withContext(Dispatchers.IO) {
@@ -25,14 +25,15 @@ class PlaceRecommendRepository @Inject constructor(
 
                 if (!resp.isSuccessful || resp.body() == null) {
                     Log.d(TAG, resp.errorBody().toString())
-                    listOf<PlaceRecommendModel>()
+                    emptyList
                 }
                 val items = resp.body()?.response?.body?.items
-                items?.item ?: listOf()
-            } catch (e: HttpException) {
-                listOf()
+                items?.item ?: emptyList
             } catch (e: SocketTimeoutException) {
-                listOf()
+                emptyList
+            } catch (t: Throwable) {
+                Log.d(TAG, t.stackTraceToString())
+                emptyList
             }
         }
     }

--- a/app/src/main/java/com/thequietz/travelog/place/repository/PlaceSearchRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/repository/PlaceSearchRepository.kt
@@ -7,14 +7,15 @@ import com.thequietz.travelog.api.PlaceSearchService
 import com.thequietz.travelog.place.model.PlaceSearchModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import retrofit2.HttpException
 import retrofit2.awaitResponse
+import java.net.SocketTimeoutException
 import javax.inject.Inject
 
 class PlaceSearchRepository @Inject constructor(
     private val service: PlaceSearchService,
 ) {
     private val TAG = "PLACE_SEARCH"
+    private val emptyList = emptyList<PlaceSearchModel>()
 
     suspend fun loadPlaceList(query: String): List<PlaceSearchModel> {
         return withContext(Dispatchers.IO) {
@@ -24,15 +25,18 @@ class PlaceSearchRepository @Inject constructor(
                 val resp = call.awaitResponse()
                 if (!resp.isSuccessful || resp.body() == null) {
                     Log.d(TAG, resp.errorBody().toString())
-                    listOf<PlaceSearchModel>()
+                    emptyList
                 }
-                resp.body()?.results ?: listOf()
-            } catch (e: HttpException) {
-                Log.d(TAG, e.message())
-                listOf()
+                resp.body()?.results ?: emptyList
+            } catch (e: SocketTimeoutException) {
+                Log.d(TAG, e.message.toString())
+                emptyList
             } catch (e: JsonSyntaxException) {
                 Log.d(TAG, e.message.toString())
-                listOf()
+                emptyList
+            } catch (t: Throwable) {
+                Log.d(TAG, t.stackTraceToString())
+                emptyList
             }
         }
     }

--- a/app/src/main/java/com/thequietz/travelog/place/viewmodel/PlaceDetailViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/viewmodel/PlaceDetailViewModel.kt
@@ -1,5 +1,7 @@
 package com.thequietz.travelog.place.viewmodel
 
+import android.os.Build
+import android.text.Html
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -60,6 +62,11 @@ class PlaceDetailViewModel @Inject constructor(
         viewModelScope.launch {
             val images = repository.loadPlaceImages(typeId, id)
             val info = repository.loadPlaceInfo(typeId, id)
+            val overview = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                Html.fromHtml(info?.overview, Html.FROM_HTML_MODE_COMPACT)
+            } else {
+                Html.fromHtml(info?.overview ?: "")
+            }
             _detail.value = PlaceDetailModel(
                 placeId = id.toString(),
                 address = info?.address ?: "",
@@ -76,7 +83,7 @@ class PlaceDetailViewModel @Inject constructor(
                 reviews = listOf(),
                 types = listOf(typeMap[typeId] ?: "Unknown"),
                 website = info?.url ?: "",
-                overview = info?.overview ?: ""
+                overview = overview.toString()
             )
         }
     }

--- a/app/src/main/java/com/thequietz/travelog/schedule/adapter/SchedulePlaceAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/adapter/SchedulePlaceAdapter.kt
@@ -20,6 +20,7 @@ class SchedulePlaceAdapter(
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(model: PlaceModel, position: Int, listener: OnItemClickListener) {
+            binding.model = model
             binding.tvGuideItem.text = model.cityName
             binding.ibGuideItem.setOnClickListener { v ->
                 when (model.isSelected) {

--- a/app/src/main/java/com/thequietz/travelog/schedule/repository/SchedulePlaceRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/repository/SchedulePlaceRepository.kt
@@ -6,7 +6,6 @@ import com.thequietz.travelog.api.PlaceService
 import com.thequietz.travelog.schedule.model.PlaceModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import retrofit2.HttpException
 import retrofit2.awaitResponse
 import javax.inject.Inject
 
@@ -14,6 +13,7 @@ class SchedulePlaceRepository @Inject constructor(
     private val placeService: PlaceService
 ) {
     private val TAG = "SCHEDULE_PLACE"
+    private val emptyList = emptyList<PlaceModel>()
 
     suspend fun loadPlaceList(): List<PlaceModel> {
         return withContext(Dispatchers.IO) {
@@ -23,15 +23,14 @@ class SchedulePlaceRepository @Inject constructor(
                 val resp = call.awaitResponse()
                 if (!resp.isSuccessful || resp.body() == null) {
                     Log.d(TAG, resp.message())
-                    listOf<PlaceModel>()
                 }
                 resp.body()?.data ?: listOf()
-            } catch (e: HttpException) {
-                Log.d(TAG, e.message())
-                listOf()
             } catch (e: JsonSyntaxException) {
                 Log.d(TAG, e.message.toString())
-                listOf()
+                emptyList
+            } catch (t: Throwable) {
+                Log.d(TAG, t.stackTraceToString())
+                emptyList
             }
         }
     }
@@ -44,13 +43,13 @@ class SchedulePlaceRepository @Inject constructor(
                 if (!resp.isSuccessful || resp.body() == null) {
                     Log.d(TAG, resp.errorBody().toString())
                 }
-                resp.body()?.data ?: listOf()
-            } catch (e: HttpException) {
-                Log.d(TAG, e.message())
-                listOf()
+                resp.body()?.data ?: emptyList
             } catch (e: JsonSyntaxException) {
                 Log.d(TAG, e.message.toString())
-                listOf()
+                emptyList
+            } catch (t: Throwable) {
+                Log.d(TAG, t.stackTraceToString())
+                emptyList
             }
         }
     }

--- a/app/src/main/java/com/thequietz/travelog/schedule/view/SchedulePlaceFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/view/SchedulePlaceFragment.kt
@@ -14,7 +14,6 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.google.gson.Gson
 import com.thequietz.travelog.R
 import com.thequietz.travelog.databinding.FragmentSchedulePlaceBinding
@@ -99,8 +98,11 @@ class SchedulePlaceFragment : Fragment() {
             schedulePlaceAdapter = SchedulePlaceAdapter(
                 object : SchedulePlaceAdapter.OnItemClickListener {
                     override fun onItemClick(view: View, position: Int, toggle: Boolean) {
+                        val state = binding.rvSelectSearch.layoutManager?.onSaveInstanceState()
+                        viewModel.saveViewState(state)
                         when (toggle) {
                             true -> viewModel.addPlaceSelectedList(it[position])
+
                             false -> viewModel.removePlaceSelectedList(it[position].cityName)
                         }
                     }
@@ -108,24 +110,28 @@ class SchedulePlaceFragment : Fragment() {
             )
 
             binding.rvSelectSearch.adapter = schedulePlaceAdapter
-            (binding.rvSelectSearch.adapter as SchedulePlaceAdapter).stateRestorationPolicy =
-                RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
-
             binding.rvSelectSearch.layoutManager = GridLayoutManager(mContext, 2)
             binding.lifecycleOwner = viewLifecycleOwner
+
+            binding.rvSelectSearch.layoutManager?.onRestoreInstanceState(viewModel.viewState.value)
             schedulePlaceAdapter.submitList(it)
         })
 
         viewModel.placeSelectedList.observe(viewLifecycleOwner, {
             if (it.size == 0) {
                 binding.btnSelectDate.setDisable()
+                binding.rvSelectItem.visibility = View.GONE
             } else {
                 binding.btnSelectDate.setEnable()
+                binding.rvSelectItem.visibility = View.VISIBLE
             }
 
             schedulePlaceSelectedAdapter = SchedulePlaceSelectedAdapter(
                 object : SchedulePlaceSelectedAdapter.OnItemClickListener {
                     override fun onItemClick(view: View, position: Int) {
+                        val state = binding.rvSelectSearch.layoutManager?.onSaveInstanceState()
+                        viewModel.saveViewState(state)
+
                         viewModel.removePlaceSelectedList(it[position].cityName)
                     }
                 }

--- a/app/src/main/java/com/thequietz/travelog/schedule/viewmodel/SchedulePlaceViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/viewmodel/SchedulePlaceViewModel.kt
@@ -1,5 +1,6 @@
 package com.thequietz.travelog.schedule.viewmodel
 
+import android.os.Parcelable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -17,11 +18,11 @@ class SchedulePlaceViewModel @Inject constructor(
     private var _placeList = MutableLiveData<List<PlaceModel>>()
     val placeList: LiveData<List<PlaceModel>> = _placeList
 
-    /*private var _selectedPlaces = MutableLiveData<MutableList<PlaceModel>>()
-    val selectedPlaces: LiveData<MutableList<PlaceModel>> = _selectedPlaces*/
-
     private var _placeSelectedList = MutableLiveData<MutableList<PlaceModel>>()
     val placeSelectedList: LiveData<MutableList<PlaceModel>> = _placeSelectedList
+
+    private var _viewState = MutableLiveData<Parcelable>()
+    val viewState: LiveData<Parcelable> get() = _viewState
 
     fun loadPlaceList() {
         viewModelScope.launch {
@@ -57,5 +58,10 @@ class SchedulePlaceViewModel @Inject constructor(
             }
         }
         _placeList.value = _placeList.value
+    }
+
+    fun saveViewState(viewState: Parcelable?) {
+        val newViewState = viewState ?: return
+        _viewState.value = newViewState
     }
 }

--- a/app/src/main/res/layout/fragment_place_detail.xml
+++ b/app/src/main/res/layout/fragment_place_detail.xml
@@ -27,6 +27,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:fitsSystemWindows="true"
+                app:contentScrim="?attr/colorPrimary"
                 app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
                 <LinearLayout

--- a/app/src/main/res/layout/fragment_schedule_place.xml
+++ b/app/src/main/res/layout/fragment_schedule_place.xml
@@ -3,6 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <data>
+        <variable
+            name="viewModel"
+            type="com.thequietz.travelog.schedule.viewmodel.SchedulePlaceViewModel" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/cl_schedule_place"
         android:layout_width="match_parent"
@@ -81,10 +87,11 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_select_item"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginVertical="4dp"
             android:orientation="horizontal"
+            android:visibility="gone"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_recycler_schedule_place.xml
+++ b/app/src/main/res/layout/item_recycler_schedule_place.xml
@@ -5,8 +5,8 @@
     <data>
 
         <variable
-            name="viewModel"
-            type="com.thequietz.travelog.schedule.viewmodel.SchedulePlaceViewModel" />
+            name="model"
+            type="com.thequietz.travelog.schedule.model.PlaceModel" />
     </data>
 
     <RelativeLayout


### PR DESCRIPTION
# #75

## 작업 내용
LayoutManager의 onSaveInstanceState 함수를 사용
- 여행 지역을 선택할 때마다 해당 함수를 실행시켜 리사이클러 뷰의 상태 저장
- 선택된 여행 지역을 이미지 버튼을 눌러 제거할 때마다 함수를 실행시켜 리사이클러 뷰의 상태 저장
- 선택된 여행 지역을 하단 선택된 여행지 목록 내에서 버튼을 눌러 제거할 때마다 함수를 실행시켜 리사이클러 뷰의 상태 저장

LayoutManager의 onRestoreInstanceState 함수를 사용
- 선택된 여행 지역을 제거할 때마다 함수를 실행시켜 최근에 저장된 리사이클러 뷰의 상태 복원