### PR TITLE
#92 #93 [일정 설정 완료 화면] 레이아웃 구성 & 일정 열람

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,16 +48,16 @@ android {
 dependencies {
 
     implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.appcompat:appcompat:1.4.0'
     implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
     implementation "androidx.activity:activity-ktx:1.4.0"
-    implementation "androidx.fragment:fragment-ktx:1.3.6"
+    implementation "androidx.fragment:fragment-ktx:1.4.0"
 
     // RecyclerView
     implementation "androidx.recyclerview:recyclerview:1.2.1"
@@ -74,8 +74,8 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
 
     // Glide
-    implementation 'com.github.bumptech.glide:glide:4.11.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
 
     // Navigation
     implementation 'androidx.navigation:navigation-fragment-ktx:2.4.0-beta01'
@@ -86,8 +86,8 @@ dependencies {
     kapt "androidx.room:room-compiler:2.3.0"
 
     // Hilt
-    implementation "com.google.dagger:hilt-android:2.36"
-    kapt "com.google.dagger:hilt-android-compiler:2.36"
+    implementation "com.google.dagger:hilt-android:2.40"
+    kapt "com.google.dagger:hilt-android-compiler:2.40"
 
     // Date Range Picker
     implementation 'com.andrewjapar.rangedatepicker:rangedatepicker:0.2.1'
@@ -105,4 +105,7 @@ dependencies {
 
     // swipe refresh
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
+
+    // ViewPager2
+    implementation "androidx.viewpager2:viewpager2:1.0.0"
 }

--- a/app/src/main/java/com/thequietz/travelog/api/PlaceSearchService.kt
+++ b/app/src/main/java/com/thequietz/travelog/api/PlaceSearchService.kt
@@ -13,14 +13,15 @@ interface PlaceSearchService {
     @GET("maps/api/place/textsearch/json")
     fun loadPlaceList(
         @Query("query") query: String,
+        @Query("language") language: String? = "ko",
         @Query("key") key: String
     ): Call<PlaceSearchModelResponse>
 
     @GET("maps/api/place/details/json")
     fun loadPlaceDetail(
         @Query("place_id") placeId: String,
+        @Query("language") language: String? = "ko",
         @Query("key") key: String,
-        @Query("language") language: String? = "ko"
     ): Call<PlaceDetailModelResponse>
 
     companion object {

--- a/app/src/main/java/com/thequietz/travelog/confirm/adapter/ConfirmDayAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/adapter/ConfirmDayAdapter.kt
@@ -1,0 +1,56 @@
+package com.thequietz.travelog.confirm.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.thequietz.travelog.R
+import com.thequietz.travelog.databinding.ItemRecyclerConfirmKeyBinding
+
+class ConfirmDayAdapter(
+    private val onClickListener: OnClickListener
+) :
+    ListAdapter<String, ConfirmDayAdapter.ViewHolder>(ConfirmDayDiffUtil()) {
+
+    class ViewHolder(val binding: ItemRecyclerConfirmKeyBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(value: String, listener: OnClickListener, position: Int) {
+            binding.value = value
+            binding.btnConfirmKey.setOnClickListener {
+                listener.onClick(position)
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding: ItemRecyclerConfirmKeyBinding = DataBindingUtil.inflate(
+            LayoutInflater.from(parent.context),
+            R.layout.item_recycler_confirm_key,
+            parent,
+            false
+        )
+        val viewHolder = ViewHolder(binding)
+        return viewHolder
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position), onClickListener, position)
+    }
+
+    interface OnClickListener {
+        fun onClick(index: Int)
+    }
+}
+
+private class ConfirmDayDiffUtil : DiffUtil.ItemCallback<String>() {
+    override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+        return oldItem == newItem
+    }
+
+    override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/app/src/main/java/com/thequietz/travelog/confirm/adapter/ConfirmPagerAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/adapter/ConfirmPagerAdapter.kt
@@ -1,0 +1,3 @@
+package com.thequietz.travelog.confirm.adapter
+
+class ConfirmPagerAdapter

--- a/app/src/main/java/com/thequietz/travelog/confirm/adapter/ConfirmPagerAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/adapter/ConfirmPagerAdapter.kt
@@ -1,3 +1,60 @@
 package com.thequietz.travelog.confirm.adapter
 
-class ConfirmPagerAdapter
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.thequietz.travelog.R
+import com.thequietz.travelog.databinding.ItemRecyclerConfirmPageBinding
+import com.thequietz.travelog.schedule.model.ScheduleDetailModel
+
+class ConfirmPagerAdapter :
+    ListAdapter<ScheduleDetailModel, ConfirmPagerAdapter.ViewHolder>(ConfirmPagerDiffUtil()) {
+
+    class ViewHolder(val binding: ItemRecyclerConfirmPageBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(model: ScheduleDetailModel) {
+            binding.model = model
+            val imageUrl = model.destination.images.firstOrNull()?.imageUrl ?: model.place.thumbnail
+
+            Glide.with(binding.ivConfirmPage)
+                .load(imageUrl)
+                .centerCrop()
+                .into(binding.ivConfirmPage)
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding: ItemRecyclerConfirmPageBinding = DataBindingUtil.inflate(
+            LayoutInflater.from(parent.context),
+            R.layout.item_recycler_confirm_page,
+            parent,
+            false
+        )
+        val viewHolder = ViewHolder(binding)
+        return viewHolder
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+}
+
+private class ConfirmPagerDiffUtil : DiffUtil.ItemCallback<ScheduleDetailModel>() {
+    override fun areItemsTheSame(
+        oldItem: ScheduleDetailModel,
+        newItem: ScheduleDetailModel
+    ): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(
+        oldItem: ScheduleDetailModel,
+        newItem: ScheduleDetailModel
+    ): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/app/src/main/java/com/thequietz/travelog/confirm/model/ConfirmModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/model/ConfirmModel.kt
@@ -1,0 +1,3 @@
+package com.thequietz.travelog.confirm.model
+
+class ConfirmModel

--- a/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
@@ -9,8 +9,10 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
+import androidx.viewpager2.widget.ViewPager2
 import com.thequietz.travelog.R
 import com.thequietz.travelog.confirm.adapter.ConfirmDayAdapter
+import com.thequietz.travelog.confirm.adapter.ConfirmPagerAdapter
 import com.thequietz.travelog.confirm.viewmodel.ConfirmViewModel
 import com.thequietz.travelog.databinding.FragmentConfirmBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -23,6 +25,7 @@ class ConfirmFragment : Fragment() {
 
     private lateinit var _context: Context
     private lateinit var dayAdapter: ConfirmDayAdapter
+    private lateinit var pageAdapter: ConfirmPagerAdapter
 
     private val navArgs: ConfirmFragmentArgs by navArgs()
     private val viewModel: ConfirmViewModel by viewModels()
@@ -47,14 +50,27 @@ class ConfirmFragment : Fragment() {
 
         dayAdapter = ConfirmDayAdapter(object : ConfirmDayAdapter.OnClickListener {
             override fun onClick(index: Int) {
-                TODO("Not yet implemented")
+                pageAdapter.submitList(viewModel.schedules.value?.get("Day ${index + 1}"))
+                binding.vpConfirmPlace.let {
+                    it.post {
+                        it.setCurrentItem(0, true)
+                    }
+                }
             }
         })
+        pageAdapter = ConfirmPagerAdapter()
+
         binding.rvConfirmHeader.adapter = dayAdapter
+        binding.vpConfirmPlace.adapter = pageAdapter
+        binding.vpConfirmPlace.orientation = ViewPager2.ORIENTATION_HORIZONTAL
+
         binding.lifecycleOwner = viewLifecycleOwner
 
         viewModel.schedules.observe(viewLifecycleOwner, {
-            dayAdapter.submitList(it.keys.toList())
+            val keys = it.keys.toList()
+
+            dayAdapter.submitList(keys)
+            pageAdapter.submitList(it[keys[0]])
         })
 
         viewModel.getSchedulesByNavArgs(navArgs.schedules)

--- a/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
@@ -7,15 +7,25 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.navArgs
 import com.thequietz.travelog.R
+import com.thequietz.travelog.confirm.adapter.ConfirmDayAdapter
+import com.thequietz.travelog.confirm.viewmodel.ConfirmViewModel
 import com.thequietz.travelog.databinding.FragmentConfirmBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class ConfirmFragment : Fragment() {
 
     private var _binding: FragmentConfirmBinding? = null
     private val binding get() = _binding!!
 
     private lateinit var _context: Context
+    private lateinit var dayAdapter: ConfirmDayAdapter
+
+    private val navArgs: ConfirmFragmentArgs by navArgs()
+    private val viewModel: ConfirmViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,5 +44,19 @@ class ConfirmFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        dayAdapter = ConfirmDayAdapter(object : ConfirmDayAdapter.OnClickListener {
+            override fun onClick(index: Int) {
+                TODO("Not yet implemented")
+            }
+        })
+        binding.rvConfirmHeader.adapter = dayAdapter
+        binding.lifecycleOwner = viewLifecycleOwner
+
+        viewModel.schedules.observe(viewLifecycleOwner, {
+            dayAdapter.submitList(it.keys.toList())
+        })
+
+        viewModel.getSchedulesByNavArgs(navArgs.schedules)
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
@@ -1,0 +1,38 @@
+package com.thequietz.travelog.confirm.view
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import com.thequietz.travelog.R
+import com.thequietz.travelog.databinding.FragmentConfirmBinding
+
+class ConfirmFragment : Fragment() {
+
+    private var _binding: FragmentConfirmBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var _context: Context
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DataBindingUtil.inflate(inflater, R.layout.fragment_confirm, container, false)
+        _context = requireContext()
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/app/src/main/java/com/thequietz/travelog/confirm/viewmodel/ConfirmViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/viewmodel/ConfirmViewModel.kt
@@ -1,0 +1,5 @@
+package com.thequietz.travelog.confirm.viewmodel
+
+import androidx.lifecycle.ViewModel
+
+class ConfirmViewModel : ViewModel()

--- a/app/src/main/java/com/thequietz/travelog/confirm/viewmodel/ConfirmViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/viewmodel/ConfirmViewModel.kt
@@ -1,5 +1,25 @@
 package com.thequietz.travelog.confirm.viewmodel
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.thequietz.travelog.schedule.model.ScheduleDetailModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class ConfirmViewModel : ViewModel()
+@HiltViewModel
+class ConfirmViewModel @Inject constructor() : ViewModel() {
+    private var _schedules = MutableLiveData<Map<String, List<ScheduleDetailModel>>>()
+    val schedules: LiveData<Map<String, List<ScheduleDetailModel>>> get() = _schedules
+
+    fun getSchedulesByNavArgs(schedules: Array<ScheduleDetailModel>) {
+        val dataSet = schedules.map { it.date }.toSet()
+        val newDataMap = mutableMapOf<String, List<ScheduleDetailModel>>()
+
+        dataSet.forEachIndexed { idx, it ->
+            newDataMap["Day ${idx + 1}"] = schedules.filter { schedule -> schedule.date == it }.toList()
+        }
+
+        _schedules.value = newDataMap
+    }
+}

--- a/app/src/main/java/com/thequietz/travelog/place/repository/PlaceDetailRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/repository/PlaceDetailRepository.kt
@@ -28,7 +28,7 @@ class PlaceDetailRepository @Inject constructor(
         return withContext(Dispatchers.IO) {
             try {
                 val apiKey = BuildConfig.GOOGLE_MAP_KEY
-                val call = searchService.loadPlaceDetail(placeId, apiKey)
+                val call = searchService.loadPlaceDetail(placeId, "ko", apiKey)
                 val resp = call.awaitResponse()
                 if (!resp.isSuccessful || resp.body() == null) {
                     Log.d(TAG, resp.errorBody().toString())

--- a/app/src/main/java/com/thequietz/travelog/place/repository/PlaceRecommendRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/repository/PlaceRecommendRepository.kt
@@ -19,7 +19,7 @@ class PlaceRecommendRepository @Inject constructor(
     suspend fun loadPlaceData(typeId: Int): List<PlaceRecommendModel> {
         return withContext(Dispatchers.IO) {
             try {
-                val apiKey = BuildConfig.TOUR_API_KEY
+                val apiKey = BuildConfig.NEW_TOUR_API_KEY
                 val call = service.loadRecommendPlace(typeId, apiKey)
                 val resp = call.awaitResponse()
 

--- a/app/src/main/java/com/thequietz/travelog/place/repository/PlaceSearchRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/repository/PlaceSearchRepository.kt
@@ -21,7 +21,7 @@ class PlaceSearchRepository @Inject constructor(
         return withContext(Dispatchers.IO) {
             try {
                 val apiKey = BuildConfig.GOOGLE_MAP_KEY
-                val call = service.loadPlaceList(query, apiKey)
+                val call = service.loadPlaceList(query, "ko", apiKey)
                 val resp = call.awaitResponse()
                 if (!resp.isSuccessful || resp.body() == null) {
                     Log.d(TAG, resp.errorBody().toString())

--- a/app/src/main/java/com/thequietz/travelog/place/viewmodel/PlaceDetailViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/viewmodel/PlaceDetailViewModel.kt
@@ -14,6 +14,8 @@ import com.thequietz.travelog.place.model.PlaceDetailModel
 import com.thequietz.travelog.place.model.PlaceDetailOperation
 import com.thequietz.travelog.place.repository.PlaceDetailRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -42,8 +44,15 @@ class PlaceDetailViewModel @Inject constructor(
 
     var isLoaded = MutableLiveData(false)
 
+    private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        Log.d("ERROR", throwable.stackTraceToString())
+        null
+    }
+
+    private val handler = Dispatchers.Main + exceptionHandler
+
     fun loadDetailBySearch(placeId: String) {
-        viewModelScope.launch {
+        viewModelScope.launch(handler) {
             val data = repository.loadPlaceDetail(placeId)
             Log.d(TAG, data.toString())
 
@@ -59,7 +68,7 @@ class PlaceDetailViewModel @Inject constructor(
 
     fun loadDetailByRecommend(id: Long, typeId: Int) {
         Log.d(TAG, "Detail Data Loaded")
-        viewModelScope.launch {
+        viewModelScope.launch(handler) {
             val images = repository.loadPlaceImages(typeId, id)
             val info = repository.loadPlaceInfo(typeId, id)
             val overview = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {

--- a/app/src/main/java/com/thequietz/travelog/record/viewmodel/RecordViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/record/viewmodel/RecordViewModel.kt
@@ -21,7 +21,7 @@ class RecordViewModel @Inject constructor(
     val recordList: LiveData<List<Record>> = _recordList
 
     init {
-        TODO("Schedule 테이블에서 데이터 로드 후 Record 테이블에 저장")
+        // TODO("Schedule 테이블에서 데이터 로드 후 Record 테이블에 저장")
         viewModelScope.launch {
             val recordImages = withContext(Dispatchers.IO) {
                 repository.loadRecordImages()

--- a/app/src/main/java/com/thequietz/travelog/schedule/view/ScheduleDetailFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/view/ScheduleDetailFragment.kt
@@ -39,10 +39,25 @@ class ScheduleDetailFragment :
             viewModel.loadSchedule(args.schedule)
 
         binding.btnNext.setOnClickListener {
+            val schedules = viewModel.detailList.value?.toTypedArray()
+            if (schedules == null || schedules.isEmpty()) {
+                return@setOnClickListener
+            }
             viewModel.saveSchedule()
+            Log.d(
+                "LIST",
+                viewModel.detailList
+                    .value?.fold("", { acc, v -> acc + v.date + "\t" }) ?: ""
+            )
+
             val action =
-                ScheduleDetailFragmentDirections.actionScheduleDetailFragmentToScheduleFragment()
+                ScheduleDetailFragmentDirections.actionScheduleDetailFragmentToConfirmFragment(
+                    schedules
+                )
             findNavController().navigate(action)
+            /*val action =
+                ScheduleDetailFragmentDirections.actionScheduleDetailFragmentToScheduleFragment()
+            findNavController().navigate(action)*/
         }
 
         val stateHandle = findNavController().currentBackStackEntry?.savedStateHandle

--- a/app/src/main/java/com/thequietz/travelog/schedule/view/SchedulePlaceFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/view/SchedulePlaceFragment.kt
@@ -87,7 +87,7 @@ class SchedulePlaceFragment : Fragment() {
             it.findNavController().navigate(action)
         }
 
-        viewModel.schedulePlaceList.observe(viewLifecycleOwner, {
+        viewModel.placeList.observe(viewLifecycleOwner, {
 
             binding.tvEmptyResult.visibility = if (it.isEmpty()) {
                 View.VISIBLE

--- a/app/src/main/java/com/thequietz/travelog/schedule/viewmodel/SchedulePlaceViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/viewmodel/SchedulePlaceViewModel.kt
@@ -1,6 +1,7 @@
 package com.thequietz.travelog.schedule.viewmodel
 
 import android.os.Parcelable
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -8,6 +9,8 @@ import androidx.lifecycle.viewModelScope
 import com.thequietz.travelog.schedule.model.SchedulePlaceModel
 import com.thequietz.travelog.schedule.repository.SchedulePlaceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -18,8 +21,10 @@ class SchedulePlaceViewModel @Inject constructor(
     private var _placeList = MutableLiveData<List<SchedulePlaceModel>>()
     val schedulePlaceList: LiveData<List<SchedulePlaceModel>> = _placeList
 
-    /*private var _selectedPlaces = MutableLiveData<MutableList<PlaceModel>>()
-    val selectedPlaces: LiveData<MutableList<PlaceModel>> = _selectedPlaces*/
+    val handler = CoroutineExceptionHandler { _, throwable ->
+        Log.d("ERROR", throwable.stackTraceToString())
+        null
+    }
 
     private var _placeSelectedList = MutableLiveData<MutableList<SchedulePlaceModel>>()
     val placeSelectedList: LiveData<MutableList<SchedulePlaceModel>> = _placeSelectedList
@@ -28,7 +33,7 @@ class SchedulePlaceViewModel @Inject constructor(
     val viewState: LiveData<Parcelable> get() = _viewState
 
     fun loadPlaceList() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.Main + handler) {
             _placeList.value = repository.loadPlaceList()
         }
     }

--- a/app/src/main/java/com/thequietz/travelog/schedule/viewmodel/SchedulePlaceViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/viewmodel/SchedulePlaceViewModel.kt
@@ -19,7 +19,7 @@ class SchedulePlaceViewModel @Inject constructor(
     private val repository: SchedulePlaceRepository
 ) : ViewModel() {
     private var _placeList = MutableLiveData<List<SchedulePlaceModel>>()
-    val schedulePlaceList: LiveData<List<SchedulePlaceModel>> = _placeList
+    val placeList: LiveData<List<SchedulePlaceModel>> = _placeList
 
     val handler = CoroutineExceptionHandler { _, throwable ->
         Log.d("ERROR", throwable.stackTraceToString())

--- a/app/src/main/res/layout/fragment_confirm.xml
+++ b/app/src/main/res/layout/fragment_confirm.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".confirm.view.ConfirmFragment">
+
+        <Button
+            android:id="@+id/btn_confirm_back"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="10dp"
+            android:background="@drawable/bg_btn_back"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_confirm_header"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/tv_schedule_setting"
+            android:textColor="@color/black"
+            android:textSize="20sp"
+            app:layout_constraintBottom_toBottomOf="@id/btn_confirm_back"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="@id/btn_confirm_back" />
+
+        <Button
+            android:id="@+id/btn_confirm"
+            android:layout_width="72dp"
+            android:layout_height="36dp"
+            android:layout_marginEnd="10dp"
+            android:background="@drawable/selector_btn_next"
+            android:text="@string/btn_done"
+            android:textColor="@color/white"
+            app:layout_constraintBottom_toBottomOf="@id/btn_confirm_back"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/btn_confirm_back" />
+
+        <fragment
+            android:id="@+id/fragment_map"
+            android:name="com.google.android.gms.maps.SupportMapFragment"
+            android:layout_width="0dp"
+            android:layout_height="420dp"
+            android:layout_marginTop="10dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_confirm_back"
+            tools:layout="@layout/abc_search_view" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_confirm_header"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:orientation="horizontal"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/fragment_map" />
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/rv_confirm_header" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_confirm.xml
+++ b/app/src/main/res/layout/fragment_confirm.xml
@@ -67,6 +67,7 @@
             tools:listitem="@layout/item_recycler_confirm_key" />
 
         <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/vp_confirm_place"
             android:layout_width="0dp"
             android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_confirm.xml
+++ b/app/src/main/res/layout/fragment_confirm.xml
@@ -55,13 +55,16 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_confirm_header"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="40dp"
+            android:layout_marginTop="10dp"
+            android:paddingHorizontal="10dp"
             android:orientation="horizontal"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/fragment_map" />
+            app:layout_constraintTop_toBottomOf="@id/fragment_map"
+            tools:listitem="@layout/item_recycler_confirm_key" />
 
         <androidx.viewpager2.widget.ViewPager2
             android:layout_width="0dp"

--- a/app/src/main/res/layout/item_recycler_confirm_key.xml
+++ b/app/src/main/res/layout/item_recycler_confirm_key.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="value"
+            type="String" />
+    </data>
+
+    <Button
+        android:id="@+id/btn_confirm_key"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="6dp"
+        android:background="@color/purple_500"
+        android:minWidth="0dp"
+        android:minHeight="0dp"
+        android:paddingHorizontal="10dp"
+        android:paddingVertical="6dp"
+        android:text="@{value}"
+        android:textColor="@color/white"
+        tools:text="Day 1" />
+
+</layout>

--- a/app/src/main/res/layout/item_recycler_confirm_page.xml
+++ b/app/src/main/res/layout/item_recycler_confirm_page.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="model"
+            type="com.thequietz.travelog.schedule.model.ScheduleDetailModel" />
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginHorizontal="30dp"
+        android:orientation="horizontal"
+        android:paddingTop="20dp"
+        android:paddingBottom="10dp">
+
+        <ImageView
+            android:id="@+id/iv_confirm_page"
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            android:layout_marginEnd="10dp"
+            tools:src="@tools:sample/avatars" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:ellipsize="end"
+                android:singleLine="true"
+                android:text="@{model.destination.name}"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                tools:text="스타벅스" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:ellipsize="end"
+                android:singleLine="true"
+                android:text="@{model.destination.types.empty ? `Unknown` : model.destination.types[0]}"
+                tools:text="카페" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:ellipsize="end"
+                android:singleLine="true"
+                android:text="@{model.destination.address}"
+                tools:text="서울시..." />
+        </LinearLayout>
+
+    </LinearLayout>
+
+</layout>

--- a/app/src/main/res/navigation/schedule.xml
+++ b/app/src/main/res/navigation/schedule.xml
@@ -55,6 +55,9 @@
         <action
             android:id="@+id/action_scheduleDetailFragment_to_placeRecommendFragment"
             app:destination="@id/placeRecommendFragment" />
+        <action
+            android:id="@+id/action_scheduleDetailFragment_to_confirmFragment"
+            app:destination="@id/confirmFragment" />
     </fragment>
     <fragment
         android:id="@+id/placeSearchFragment"
@@ -85,6 +88,14 @@
         <action
             android:id="@+id/action_placeRecommendFragment_to_placeSearchFragment"
             app:destination="@id/placeSearchFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/confirmFragment"
+        android:name="com.thequietz.travelog.confirm.view.ConfirmFragment"
+        android:label="ConfirmFragment" >
+        <argument
+            android:name="schedules"
+            app:argType="com.thequietz.travelog.schedule.model.ScheduleDetailModel[]" />
     </fragment>
 
 </navigation>

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.4.0-beta01"
 
         // Hilt
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.28-alpha'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.40'
     }
 }
 


### PR DESCRIPTION
# #92 #93

## 작업 내용
- 일정 설정 완료 화면 레이아웃 구성
- 일정 설정 완료 화면에서 각 일자마다 버튼 생성
- ViewPager2와 ListAdapter를 사용하여 여행 일정 페이징 처리

## 남은 작업
- 페이징 처리할 때마다 여행지의 좌표를 갱신하여 마커 위치 변경