### PR TITLE
#93 [일정 설정 완료 화면] 뷰페이저 페이징 처리 및 마커 출력

### DIFF
--- a/app/src/main/java/com/thequietz/travelog/confirm/adapter/ConfirmPagerAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/adapter/ConfirmPagerAdapter.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.thequietz.travelog.BuildConfig
 import com.thequietz.travelog.R
 import com.thequietz.travelog.databinding.ItemRecyclerConfirmPageBinding
 import com.thequietz.travelog.schedule.model.ScheduleDetailModel
@@ -16,12 +17,19 @@ class ConfirmPagerAdapter :
 
     class ViewHolder(val binding: ItemRecyclerConfirmPageBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(model: ScheduleDetailModel) {
+        fun bind(model: ScheduleDetailModel?) {
             binding.model = model
-            val imageUrl = model.destination.images.firstOrNull()?.imageUrl ?: model.place.thumbnail
+
+            val apiKey = BuildConfig.GOOGLE_MAP_KEY
+            val reservedSrc = "Aap_uECPoBEl_RLC8YDMxcIulQ7fGfCdt2Jvn677nHTQPa0VWcAnYCeuogtdj7-V--YYtaOFZf1W1UGA__J62jjaf32djXMLYkbkYuR4KZuiP20t-jKmK56akJZr9TQ9hcs_RO1_iWjo6FrcloCSgJ_e5Gd20nC0AfZiu3AYuP4sVgG6j-kj"
+
+            val imageUrl = model?.destination?.images?.firstOrNull()
+            val imageId = model?.destination?.images?.firstOrNull()?.imageId
+            val imageSrc = imageUrl?.imageUrl
+                ?: "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${imageId ?: reservedSrc}&key=$apiKey"
 
             Glide.with(binding.ivConfirmPage)
-                .load(imageUrl)
+                .load(imageSrc)
                 .centerCrop()
                 .into(binding.ivConfirmPage)
         }

--- a/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
@@ -2,6 +2,7 @@ package com.thequietz.travelog.confirm.view
 
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -50,12 +51,7 @@ class ConfirmFragment : Fragment() {
 
         dayAdapter = ConfirmDayAdapter(object : ConfirmDayAdapter.OnClickListener {
             override fun onClick(index: Int) {
-                pageAdapter.submitList(viewModel.schedules.value?.get("Day ${index + 1}"))
-                binding.vpConfirmPlace.let {
-                    it.post {
-                        it.setCurrentItem(0, true)
-                    }
-                }
+                viewModel.updateSchedule("Day ${index + 1}")
             }
         })
         pageAdapter = ConfirmPagerAdapter()
@@ -63,6 +59,14 @@ class ConfirmFragment : Fragment() {
         binding.rvConfirmHeader.adapter = dayAdapter
         binding.vpConfirmPlace.adapter = pageAdapter
         binding.vpConfirmPlace.orientation = ViewPager2.ORIENTATION_HORIZONTAL
+        binding.vpConfirmPlace.registerOnPageChangeCallback(object :
+                ViewPager2.OnPageChangeCallback() {
+                override fun onPageSelected(position: Int) {
+                    super.onPageSelected(position)
+
+                    Log.d("PAGE", viewModel.currentSchedule.value?.get(position).toString())
+                }
+            })
 
         binding.lifecycleOwner = viewLifecycleOwner
 
@@ -70,9 +74,22 @@ class ConfirmFragment : Fragment() {
             val keys = it.keys.toList()
 
             dayAdapter.submitList(keys)
-            pageAdapter.submitList(it[keys[0]])
+            viewModel.updateSchedule(keys[0])
+        })
+
+        viewModel.currentSchedule.observe(viewLifecycleOwner, {
+            pageAdapter.submitList(it)
+            binding.vpConfirmPlace.let { pager ->
+                pager.post {
+                    pager.setCurrentItem(0, true)
+                }
+            }
         })
 
         viewModel.getSchedulesByNavArgs(navArgs.schedules)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
@@ -2,53 +2,49 @@ package com.thequietz.travelog.confirm.view
 
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
 import androidx.viewpager2.widget.ViewPager2
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.model.LatLng
 import com.thequietz.travelog.R
 import com.thequietz.travelog.confirm.adapter.ConfirmDayAdapter
 import com.thequietz.travelog.confirm.adapter.ConfirmPagerAdapter
 import com.thequietz.travelog.confirm.viewmodel.ConfirmViewModel
 import com.thequietz.travelog.databinding.FragmentConfirmBinding
+import com.thequietz.travelog.map.GoogleMapFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class ConfirmFragment : Fragment() {
+class ConfirmFragment : GoogleMapFragment<FragmentConfirmBinding, ConfirmViewModel>() {
 
-    private var _binding: FragmentConfirmBinding? = null
-    private val binding get() = _binding!!
+    override val layoutId = R.layout.fragment_confirm
+    override val viewModel: ConfirmViewModel by viewModels()
+    override var drawMarker = true
+    override var isMarkerNumbered = true
+    override var drawOrderedPolyline = true
+
+    override fun onMapReady(googleMap: GoogleMap) {
+        super.onMapReady(googleMap)
+
+        googleMap.setMinZoomPreference(15F)
+    }
 
     private lateinit var _context: Context
     private lateinit var dayAdapter: ConfirmDayAdapter
     private lateinit var pageAdapter: ConfirmPagerAdapter
 
     private val navArgs: ConfirmFragmentArgs by navArgs()
-    private val viewModel: ConfirmViewModel by viewModels()
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-    }
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = DataBindingUtil.inflate(inflater, R.layout.fragment_confirm, container, false)
-        _context = requireContext()
-
-        return binding.root
+    override fun initViewModel() {
+        binding.viewModel = viewModel
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        _context = requireContext()
         dayAdapter = ConfirmDayAdapter(object : ConfirmDayAdapter.OnClickListener {
             override fun onClick(index: Int) {
                 viewModel.updateSchedule("Day ${index + 1}")
@@ -64,7 +60,14 @@ class ConfirmFragment : Fragment() {
                 override fun onPageSelected(position: Int) {
                     super.onPageSelected(position)
 
-                    Log.d("PAGE", viewModel.currentSchedule.value?.get(position).toString())
+                    val currentItem = viewModel.currentSchedule.value?.get(position)
+                    val location = currentItem?.destination?.geometry?.location
+                    val lat = location?.latitude
+                    val lng = location?.longitude
+
+                    if (lat != null && lng != null) {
+                        targetList.value = mutableListOf(LatLng(lat, lng))
+                    }
                 }
             })
 
@@ -84,12 +87,24 @@ class ConfirmFragment : Fragment() {
                     pager.setCurrentItem(0, true)
                 }
             }
+
+            val currentItem = it.firstOrNull()
+            val location = currentItem?.destination?.geometry?.location
+            val lat = location?.latitude
+            val lng = location?.longitude
+
+            if (lat != null && lng != null) {
+                targetList.value = mutableListOf(LatLng(lat, lng))
+            }
         })
 
         viewModel.getSchedulesByNavArgs(navArgs.schedules)
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
+    override fun initTargetList() {
+        baseTargetList = navArgs.schedules.map { it ->
+            val location = it.destination.geometry.location
+            LatLng(location.latitude, location.latitude)
+        }.toMutableList()
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/confirm/viewmodel/ConfirmViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/viewmodel/ConfirmViewModel.kt
@@ -12,6 +12,9 @@ class ConfirmViewModel @Inject constructor() : ViewModel() {
     private var _schedules = MutableLiveData<Map<String, List<ScheduleDetailModel>>>()
     val schedules: LiveData<Map<String, List<ScheduleDetailModel>>> get() = _schedules
 
+    private var _currentSchedule = MutableLiveData<List<ScheduleDetailModel>>()
+    val currentSchedule: LiveData<List<ScheduleDetailModel>> get() = _currentSchedule
+
     fun getSchedulesByNavArgs(schedules: Array<ScheduleDetailModel>) {
         val dataSet = schedules.map { it.date }.toSet()
         val newDataMap = mutableMapOf<String, List<ScheduleDetailModel>>()
@@ -21,5 +24,9 @@ class ConfirmViewModel @Inject constructor() : ViewModel() {
         }
 
         _schedules.value = newDataMap
+    }
+
+    fun updateSchedule(key: String) {
+        _currentSchedule.value = schedules.value?.get(key) ?: listOf()
     }
 }

--- a/app/src/main/res/layout/fragment_confirm.xml
+++ b/app/src/main/res/layout/fragment_confirm.xml
@@ -2,6 +2,12 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+    
+    <data>
+        <variable
+            name="viewModel"
+            type="com.thequietz.travelog.confirm.viewmodel.ConfirmViewModel" />
+    </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
# #93 

## 작업 내용

- ViewPager2와 ListAdapter로 각각의 여행일마다 갈 곳을 페이지 형태로 렌더링
- 구글 맵 마커 출력
  - initTargetList에서 baseTargetList에 좌표 리스트 저장
  - 여행일이 변경되거나 페이지가 넘어갈 때마다 targetList를 변경