### PR TITLE
#44 [장소 정보 상세 화면] 가이드 화면에서 장소 정보 상세 화면으로 데이터 전달

### DIFF
--- a/app/src/main/java/com/thequietz/travelog/data/Repository.kt
+++ b/app/src/main/java/com/thequietz/travelog/data/Repository.kt
@@ -21,8 +21,8 @@ class GuideRepository @Inject constructor(
     private val guideRecommendService: GuideRecommendService
 ) {
     private val TAG = "GUIDE"
-    private val TOUR_API_KEY = BuildConfig.TOUR_API_KEY
-    private val NEW_TOUR_API_KEY = BuildConfig.NEW_TOUR_API_KEY
+    private val NEW_TOUR_API_KEY = BuildConfig.TOUR_API_KEY
+    private val TOUR_API_KEY = BuildConfig.NEW_TOUR_API_KEY
 
     private val emptyList = emptyList<Place>()
     private val emptyRecommendList = emptyList<RecommendPlace>()

--- a/app/src/main/java/com/thequietz/travelog/guide/adapter/OtherInfoAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/adapter/OtherInfoAdapter.kt
@@ -8,9 +8,7 @@ import com.google.gson.Gson
 import com.thequietz.travelog.databinding.ItemRecyclerOtherInfoBinding
 import com.thequietz.travelog.guide.RecommendPlace
 import com.thequietz.travelog.guide.view.OtherInfoFragmentDirections
-import com.thequietz.travelog.place.model.PlaceGeometry
-import com.thequietz.travelog.place.model.PlaceLocation
-import com.thequietz.travelog.place.model.PlaceSearchModel
+import com.thequietz.travelog.place.model.PlaceRecommendModel
 
 class OtherInfoAdapter : androidx.recyclerview.widget.ListAdapter<RecommendPlace, OtherInfoAdapter.OtherInfoViewHolder>(
     RecommendPlaceDiffUtilCallback()
@@ -21,14 +19,14 @@ class OtherInfoAdapter : androidx.recyclerview.widget.ListAdapter<RecommendPlace
             binding.executePendingBindings()
             itemView.setOnClickListener {
                 val param = Gson().toJson(
-                    PlaceSearchModel(
+                    PlaceRecommendModel(
                         item.name,
-                        "23",
-                        PlaceGeometry(
-                            PlaceLocation(
-                                item.latitude, item.longitude
-                            )
-                        )
+                        item.url,
+                        item.description,
+                        item.latitude,
+                        item.longitude,
+                        item.contentId,
+                        item.contentTypeId
                     )
                 )
                 val action = OtherInfoFragmentDirections

--- a/app/src/main/java/com/thequietz/travelog/guide/model/RecommendResponse.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/model/RecommendResponse.kt
@@ -5,21 +5,27 @@ import com.google.gson.annotations.SerializedName
 data class RecommendResponse(
     @SerializedName("response") val response: rResponse
 )
+
 data class rResponse(
     @SerializedName("body") val body: rBody
 )
+
 data class rBody(
     @SerializedName("items") val items: rItems,
     @SerializedName("totalCount") val totalCnt: Int
 )
+
 data class rItems(
     @SerializedName("item") val item: List<RecommendPlace>
 )
+
 data class RecommendPlace(
     @SerializedName("title") val name: String = "",
     @SerializedName("firstimage") val url: String = "",
     @SerializedName("addr1") val description: String = "",
     @SerializedName("readcount") val readCount: String,
     @SerializedName("mapx") val longitude: Double = 0.0,
-    @SerializedName("mapy") val latitude: Double = 0.0
+    @SerializedName("mapy") val latitude: Double = 0.0,
+    @SerializedName("contentid") val contentId: Long,
+    @SerializedName("contenttypeid") val contentTypeId: Int,
 )


### PR DESCRIPTION
# #44

## 작업 내용

- 가이드 추천 목록 화면에서 여행지 항목을 클릭하면 상세 정보 화면에서 렌더링
- PlaceRecommendModel 인스턴스를 하나 생성 후 직렬화하여 네비게이션으로 전달

## 작업 계획
- 가이드 추천 목록 화면에서 상세 정보 화면으로 넘어온 경우 "일정 추가" 버튼을 비활성화하거나 보이지 않게 할 필요가 있음