### PR TITLE
#121 [장소 검색 화면] 사용자 키보드 입력 처리

### DIFF
--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceDetailFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceDetailFragment.kt
@@ -1,5 +1,6 @@
 package com.thequietz.travelog.place.view
 
+import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -89,6 +90,7 @@ class PlaceDetailFragment : GoogleMapFragment<FragmentPlaceDetailBinding, PlaceD
 
         binding.rvPlaceDetail.adapter = adapter
         binding.lifecycleOwner = viewLifecycleOwner
+        binding.tblPlaceDetail.setExpandedTitleColor(Color.parseColor(getString(R.string.color_transparent)))
 
         viewModel.detail.observe(viewLifecycleOwner, {
             (binding.rvPlaceDetail.adapter as PlaceDetailAdapter).submitList(it.images)

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
@@ -90,6 +90,7 @@ class PlaceSearchFragment : GoogleMapFragment<FragmentPlaceSearchBinding, PlaceS
             if (code !== android.view.KeyEvent.KEYCODE_ENTER) return@setOnKeyListener false
             val query = (v as EditText).text.toString()
             viewModel.loadPlaceList(query)
+            inputManager.hideSoftInputFromWindow(view.windowToken, 0)
             true
         }
 

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
@@ -55,6 +55,23 @@ class PlaceSearchFragment : GoogleMapFragment<FragmentPlaceSearchBinding, PlaceS
                 )
             )
         )
+        googleMap.setOnMarkerClickListener { marker ->
+            val markerId = marker.id.substring(1).toIntOrNull()
+            val model = markerId?.let { idx ->
+                viewModel.place.value?.get(idx)
+            }
+            model?.also { it ->
+                val param = gson.toJson(it)
+                val action =
+                    PlaceSearchFragmentDirections.actionPlaceSearchFragmentToPlaceDetailFragment(
+                        param,
+                        false,
+                    )
+                findNavController().navigate(action)
+            }
+
+            true
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/thequietz/travelog/place/viewmodel/PlaceRecommendViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/viewmodel/PlaceRecommendViewModel.kt
@@ -1,5 +1,6 @@
 package com.thequietz.travelog.place.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -53,6 +54,7 @@ class PlaceRecommendViewModel @Inject constructor(
                 async { _restaurantData.value = repository.loadPlaceData(39) },
             )
             deferJobs.awaitAll()
+            Log.d("STATUS", "HTTP RESPONSE")
             _dataList.value = listOf(
                 PlaceRecommendWithList("관광지", landmarkData),
                 PlaceRecommendWithList("문화시설", cultureData),
@@ -63,5 +65,11 @@ class PlaceRecommendViewModel @Inject constructor(
                 PlaceRecommendWithList("음식점", restaurantData),
             )
         }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+
+        Log.d("STATUS", "DATA REMOVED")
     }
 }

--- a/app/src/main/res/layout/fragment_place_detail.xml
+++ b/app/src/main/res/layout/fragment_place_detail.xml
@@ -24,10 +24,12 @@
             android:fitsSystemWindows="true">
 
             <com.google.android.material.appbar.CollapsingToolbarLayout
+                android:id="@+id/tbl_place_detail"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:fitsSystemWindows="true"
                 app:contentScrim="?attr/colorPrimary"
+                app:expandedTitleTextAppearance="@android:color/transparent"
                 app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
                 <LinearLayout
@@ -57,10 +59,11 @@
                 </LinearLayout>
 
                 <androidx.appcompat.widget.Toolbar
+                    android:id="@+id/tb_place_detail"
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
                     app:layout_collapseMode="pin"
-                    app:title="@{viewModel.detail.name}" />
+                    app:title="@{viewModel.detail.name}"/>
 
             </com.google.android.material.appbar.CollapsingToolbarLayout>
 

--- a/app/src/main/res/layout/fragment_place_search.xml
+++ b/app/src/main/res/layout/fragment_place_search.xml
@@ -59,6 +59,7 @@
             android:id="@+id/rv_place_search"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="30dp"
             android:paddingHorizontal="20dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_recycler_place_search.xml
+++ b/app/src/main/res/layout/item_recycler_place_search.xml
@@ -11,15 +11,21 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="10dp"
+        android:layout_marginVertical="10dp"
+        android:elevation="3dp">
 
         <TextView
             android:id="@+id/tv_place_search_item"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingVertical="15dp"
+            android:paddingVertical="10dp"
+            android:paddingHorizontal="5dp"
             android:text="@{model.name}"
+            android:textColor="@color/black"
             android:textSize="20sp"
+            android:textStyle="bold"
             tools:text="@string/tv_place_search_item" />
     </LinearLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,5 +62,6 @@
     <string name="tv_place_review_relative_time">4일 전</string>
     <string name="tv_item_place_review_time">2021년 11월 15일</string>
     <string name="tv_item_recycler_place_recommend">관광지</string>
+    <string name="color_transparent">#00FFFFFF</string>
 
 </resources>


### PR DESCRIPTION
# #121

## 작업 내용

- 검색어 입력 후 엔터 클릭 시 키보드 해제
- 검색어 입력 후 지도에 마커 표시되고 마커 클릭 시 해당하는 순번에 해당하는 장소 정보 상세 화면 출력

# #122

## 작업 내용
- 상세 화면이 처음 보여질 때 상단 바 내 지도에서 장소 이름이 보이지 않게 한다.
- 상세 화면을 아래 쪽으로 스크롤해서 지도 크기가 작아질 때 장소 이름이 상단 바에 출력되도록 한다.
- 가이드 화면에서 추천 여행지 항목을 터치했을 경우 장소 정보 상세 화면으로 이동한다.