### PR TITLE
#121 [장소 정보 상세 화면] 추가 버튼 유무 확인

### DIFF
--- a/app/src/main/java/com/thequietz/travelog/guide/adapter/GuideMultiViewAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/adapter/GuideMultiViewAdapter.kt
@@ -45,7 +45,7 @@ class GuideMultiViewAdapter(val frag: Fragment) : ListAdapter<Guide, RecyclerVie
                 )
                 val action = GuideFragmentDirections
                     .actionGuideFragmentToPlaceDetailFragmentFromGuide(
-                        param, true
+                        param, isRecommended = true, isGuide = true
                     )
                 findNavController(frag).navigate(action)
             }

--- a/app/src/main/java/com/thequietz/travelog/guide/adapter/OtherInfoAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/adapter/OtherInfoAdapter.kt
@@ -31,7 +31,7 @@ class OtherInfoAdapter : androidx.recyclerview.widget.ListAdapter<RecommendPlace
                 )
                 val action = OtherInfoFragmentDirections
                     .actionOtherInfoFragmentToPlaceDetailFragmentFromGuide(
-                        param, true
+                        param, isRecommended = true, isGuide = true
                     )
                 it.findNavController().navigate(action)
             }

--- a/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceRecommendSpecAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/adapter/PlaceRecommendSpecAdapter.kt
@@ -41,7 +41,7 @@ class PlaceRecommendSpecAdapter(private val parentFragment: Fragment) :
                 val param = gson.toJson(model)
                 val action =
                     PlaceRecommendFragmentDirections.actionPlaceRecommendFragmentToPlaceDetailFragment(
-                        param, true,
+                        param, true, isGuide = false
                     )
                 fragment.findNavController().navigate(action)
             }

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceDetailFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceDetailFragment.kt
@@ -79,6 +79,10 @@ class PlaceDetailFragment : GoogleMapFragment<FragmentPlaceDetailBinding, PlaceD
             false -> searchModel = gson.fromJson(navArgs.param, PlaceSearchModel::class.java)
         }
 
+        if (navArgs.isGuide) {
+            binding.btnPlaceAdd.visibility = View.GONE
+        }
+
         adapter = PlaceDetailAdapter(isRecommended)
 
         val params = binding.ablPlaceDetail.layoutParams as CoordinatorLayout.LayoutParams

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
@@ -75,7 +75,8 @@ class PlaceSearchFragment : GoogleMapFragment<FragmentPlaceSearchBinding, PlaceS
                 val action =
                     PlaceSearchFragmentDirections.actionPlaceSearchFragmentToPlaceDetailFragment(
                         param,
-                        false,
+                        isRecommended = false,
+                        isGuide = false
                     )
                 findNavController().navigate(action)
             }
@@ -103,7 +104,8 @@ class PlaceSearchFragment : GoogleMapFragment<FragmentPlaceSearchBinding, PlaceS
                 val action =
                     PlaceSearchFragmentDirections.actionPlaceSearchFragmentToPlaceDetailFragment(
                         param,
-                        false,
+                        isRecommended = false,
+                        isGuide = false
                     )
                 view.findNavController().navigate(action)
                 return true

--- a/app/src/main/res/navigation/guide.xml
+++ b/app/src/main/res/navigation/guide.xml
@@ -61,6 +61,9 @@
         <argument
             android:name="isRecommended"
             app:argType="boolean" />
+        <argument
+            android:name="isGuide"
+            app:argType="boolean" />
     </fragment>
 
 </navigation>

--- a/app/src/main/res/navigation/schedule.xml
+++ b/app/src/main/res/navigation/schedule.xml
@@ -80,8 +80,7 @@
             app:argType="boolean" />
         <argument
             android:name="isGuide"
-            app:argType="boolean"
-            android:defaultValue="true" />
+            app:argType="boolean" />
     </fragment>
     <fragment
         android:id="@+id/placeRecommendFragment"

--- a/app/src/main/res/navigation/schedule.xml
+++ b/app/src/main/res/navigation/schedule.xml
@@ -78,6 +78,10 @@
         <argument
             android:name="isRecommended"
             app:argType="boolean" />
+        <argument
+            android:name="isGuide"
+            app:argType="boolean"
+            android:defaultValue="true" />
     </fragment>
     <fragment
         android:id="@+id/placeRecommendFragment"


### PR DESCRIPTION
# #121

## 작업 내용
- 장소 정보 상세 화면에서 "추가" 버튼 출력 유무 판별
  - 가이드 화면에서 추천 관광지 항목을 통해 이동하면 출력하지 않음
  - 장소 검색 화면에서 이동한 경우 추가 버튼 출력 및 여행지 추가 가능

- 네비게이션 그래프
  - 어디서 이동했는지 판별할 수 있는 불리언 변수 추가
  - 기본값 true