### PR TITLE
#156 [장소 검색 화면 & 장소 정보 상세 화면] 메모리 관리 및 지도 디자인

### DIFF
--- a/app/src/main/java/com/thequietz/travelog/MainActivity.kt
+++ b/app/src/main/java/com/thequietz/travelog/MainActivity.kt
@@ -51,6 +51,8 @@ class MainActivity : AppCompatActivity() {
                 R.id.scheduleDetailFragment,
                 R.id.confirmFragment,
                 R.id.placeRecommendFragment,
+                R.id.placeDetailFragment,
+                R.id.placeDetailFragmentFromGuide,
                 R.id.placeSearchFragment -> {
                     binding.toolbar.visibility = View.GONE
                 }

--- a/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
@@ -10,6 +10,8 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.GoogleMapOptions
+import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
 import com.thequietz.travelog.R
 import com.thequietz.travelog.confirm.adapter.ConfirmDayAdapter
@@ -28,10 +30,16 @@ class ConfirmFragment : GoogleMapFragment<FragmentConfirmBinding, ConfirmViewMod
     override var isMarkerNumbered = false
     override var drawOrderedPolyline = false
 
+    private var mapFragment: SupportMapFragment? = null
+
     override fun onMapReady(googleMap: GoogleMap) {
         super.onMapReady(googleMap)
 
-        googleMap.setMinZoomPreference(15F)
+        mapFragment = childFragmentManager.findFragmentById(R.id.fragment_map) as SupportMapFragment
+        mapFragment = mapFragment?.also {
+            val mapOptions = GoogleMapOptions().useViewLifecycleInFragment(true)
+            SupportMapFragment.newInstance(mapOptions)
+        }
     }
 
     private lateinit var _context: Context
@@ -137,5 +145,12 @@ class ConfirmFragment : GoogleMapFragment<FragmentConfirmBinding, ConfirmViewMod
             val location = it.destination.geometry.location
             LatLng(location.latitude, location.latitude)
         }.toMutableList()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        map.clear()
+        mapFragment?.onDestroyView()
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/guide/adapter/GuideMultiViewAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/adapter/GuideMultiViewAdapter.kt
@@ -2,8 +2,7 @@ package com.thequietz.travelog.guide.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.findNavController
+import androidx.navigation.Navigation
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -20,7 +19,7 @@ import com.thequietz.travelog.guide.model.GuideViewType
 import com.thequietz.travelog.guide.view.GuideFragmentDirections
 import com.thequietz.travelog.place.model.PlaceRecommendModel
 
-class GuideMultiViewAdapter(val frag: Fragment) : ListAdapter<Guide, RecyclerView.ViewHolder>(
+class GuideMultiViewAdapter : ListAdapter<Guide, RecyclerView.ViewHolder>(
     GuideDiffUtilCallback()
 ) {
     class GuideTitleViewHolder(val binding: ItemRecyclerTitleBinding) :
@@ -32,7 +31,6 @@ class GuideMultiViewAdapter(val frag: Fragment) : ListAdapter<Guide, RecyclerVie
     }
 
     class GuideRecommendViewHolder(
-        frag: Fragment,
         val binding: RecyclerGuideRecommendImageBinding
     ) : RecyclerView.ViewHolder(binding.root) {
         val adapter = RecommendMultiViewImageAdapter(object :
@@ -53,8 +51,7 @@ class GuideMultiViewAdapter(val frag: Fragment) : ListAdapter<Guide, RecyclerVie
                         .actionGuideFragmentToPlaceDetailFragmentFromGuide(
                             param, isRecommended = true, isGuide = true
                         )
-                    frag.findNavController().navigate(action)
-                    frag.onDestroyView()
+                    Navigation.findNavController(itemView).navigate(action)
                 }
             })
 
@@ -64,18 +61,19 @@ class GuideMultiViewAdapter(val frag: Fragment) : ListAdapter<Guide, RecyclerVie
 
         fun bind(recommend: Guide.SpecificRecommend) {
             adapter.submitList(recommend.specificRecommendList)
+            binding.executePendingBindings()
         }
     }
 
-    class GuideAllPlaceViewHolder(frag: Fragment, binding: RecyclerAllPlaceImageBinding) :
+    class GuideAllPlaceViewHolder(binding: RecyclerAllPlaceImageBinding) :
         RecyclerView.ViewHolder(binding.root) {
         val adapter = AllPlaceMultiViewImageAdapter(object :
                 AllPlaceMultiViewImageAdapter.OnItemClickListener {
                 override fun onItemClick(item: Place) {
                     val action = GuideFragmentDirections
                         .actionGuideFragmentToSpecificGuideFragment(item.areaCode.toString())
-                    frag.findNavController().navigate(action)
-                    frag.onDestroyView()
+
+                    Navigation.findNavController(itemView).navigate(action)
                 }
             })
 
@@ -107,7 +105,6 @@ class GuideMultiViewAdapter(val frag: Fragment) : ListAdapter<Guide, RecyclerVie
             }
             GuideViewType.RECOMMEND -> {
                 GuideRecommendViewHolder(
-                    frag,
                     RecyclerGuideRecommendImageBinding.inflate(
                         LayoutInflater.from(parent.context), parent, false
                     )
@@ -115,7 +112,6 @@ class GuideMultiViewAdapter(val frag: Fragment) : ListAdapter<Guide, RecyclerVie
             }
             GuideViewType.ALLPLACE -> {
                 GuideAllPlaceViewHolder(
-                    frag,
                     RecyclerAllPlaceImageBinding.inflate(
                         LayoutInflater.from(parent.context), parent, false
                     )
@@ -158,7 +154,7 @@ class RecommendMultiViewImageAdapter(private val onItemClickListener: OnItemClic
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int
-    ): RecommendMultiViewImageAdapter.RecommendMultiViewImageViewHolder {
+    ): RecommendMultiViewImageViewHolder {
         return RecommendMultiViewImageViewHolder(
             ItemRecyclerGuideRecommendPlaceBinding.inflate(
                 LayoutInflater.from(parent.context), parent, false
@@ -210,16 +206,6 @@ class AllPlaceMultiViewImageAdapter(
         holder.binding.ivItemPlaceAll.setOnClickListener { view ->
             onItemClickListener.onItemClick(getItem(position))
         }
-    }
-}
-
-private class GuideMultiViewDiffUtil() : DiffUtil.ItemCallback<Guide>() {
-    override fun areItemsTheSame(oldItem: Guide, newItem: Guide): Boolean {
-        return oldItem === newItem
-    }
-
-    override fun areContentsTheSame(oldItem: Guide, newItem: Guide): Boolean {
-        return oldItem == newItem
     }
 }
 

--- a/app/src/main/java/com/thequietz/travelog/guide/adapter/GuideMultiViewAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/adapter/GuideMultiViewAdapter.kt
@@ -3,7 +3,7 @@ package com.thequietz.travelog.guide.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.NavHostFragment.Companion.findNavController
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -23,55 +23,71 @@ import com.thequietz.travelog.place.model.PlaceRecommendModel
 class GuideMultiViewAdapter(val frag: Fragment) : ListAdapter<Guide, RecyclerView.ViewHolder>(
     GuideDiffUtilCallback()
 ) {
-    class GuideTitleViewHolder(val binding: ItemRecyclerTitleBinding) : RecyclerView.ViewHolder(binding.root) {
+    class GuideTitleViewHolder(val binding: ItemRecyclerTitleBinding) :
+        RecyclerView.ViewHolder(binding.root) {
         fun bind(header: Guide.Header) {
             binding.item = header
             binding.executePendingBindings()
         }
     }
-    class GuideRecommendViewHolder(frag: Fragment, val binding: RecyclerGuideRecommendImageBinding) : RecyclerView.ViewHolder(binding.root) {
-        val adapter = RecommendMultiViewImageAdapter(object : RecommendMultiViewImageAdapter.OnItemClickListener {
-            override fun onItemClick(item: RecommendPlace) {
-                val param = Gson().toJson(
-                    PlaceRecommendModel(
-                        item.name,
-                        item.url,
-                        item.description,
-                        item.latitude,
-                        item.longitude,
-                        item.contentId,
-                        item.contentTypeId
+
+    class GuideRecommendViewHolder(
+        frag: Fragment,
+        val binding: RecyclerGuideRecommendImageBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+        val adapter = RecommendMultiViewImageAdapter(object :
+                RecommendMultiViewImageAdapter.OnItemClickListener {
+                override fun onItemClick(item: RecommendPlace) {
+                    val param = Gson().toJson(
+                        PlaceRecommendModel(
+                            item.name,
+                            item.url,
+                            item.description,
+                            item.latitude,
+                            item.longitude,
+                            item.contentId,
+                            item.contentTypeId
+                        )
                     )
-                )
-                val action = GuideFragmentDirections
-                    .actionGuideFragmentToPlaceDetailFragmentFromGuide(
-                        param, isRecommended = true, isGuide = true
-                    )
-                findNavController(frag).navigate(action)
-            }
-        })
+                    val action = GuideFragmentDirections
+                        .actionGuideFragmentToPlaceDetailFragmentFromGuide(
+                            param, isRecommended = true, isGuide = true
+                        )
+                    frag.findNavController().navigate(action)
+                    frag.onDestroyView()
+                }
+            })
+
         init {
             binding.rvItemRecommendImage.adapter = adapter
         }
+
         fun bind(recommend: Guide.SpecificRecommend) {
             adapter.submitList(recommend.specificRecommendList)
         }
     }
-    class GuideAllPlaceViewHolder(frag: Fragment, binding: RecyclerAllPlaceImageBinding) : RecyclerView.ViewHolder(binding.root) {
-        val adapter = AllPlaceMultiViewImageAdapter(object : AllPlaceMultiViewImageAdapter.OnItemClickListener {
-            override fun onItemClick(item: Place) {
-                val action = GuideFragmentDirections
-                    .actionGuideFragmentToSpecificGuideFragment(item.areaCode.toString())
-                findNavController(frag).navigate(action)
-            }
-        })
+
+    class GuideAllPlaceViewHolder(frag: Fragment, binding: RecyclerAllPlaceImageBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        val adapter = AllPlaceMultiViewImageAdapter(object :
+                AllPlaceMultiViewImageAdapter.OnItemClickListener {
+                override fun onItemClick(item: Place) {
+                    val action = GuideFragmentDirections
+                        .actionGuideFragmentToSpecificGuideFragment(item.areaCode.toString())
+                    frag.findNavController().navigate(action)
+                    frag.onDestroyView()
+                }
+            })
+
         init {
             binding.rvItemAllPlaceImage.adapter = adapter
         }
+
         fun bind(dosi: Guide.Dosi) {
             adapter.submitList(dosi.specificDOSIList)
         }
     }
+
     override fun getItemViewType(position: Int): Int {
         return when (getItem(position)) {
             is Guide.Header -> 0
@@ -121,32 +137,24 @@ class GuideMultiViewAdapter(val frag: Fragment) : ListAdapter<Guide, RecyclerVie
             }
         }
     }
-
-    companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<Guide>() {
-            override fun areItemsTheSame(oldItem: Guide, newItem: Guide): Boolean {
-                return oldItem === newItem
-            }
-
-            override fun areContentsTheSame(oldItem: Guide, newItem: Guide): Boolean {
-                return oldItem == newItem
-            }
-        }
-    }
 }
 
-class RecommendMultiViewImageAdapter(private val onItemClickListener: OnItemClickListener) : ListAdapter<RecommendPlace, RecommendMultiViewImageAdapter.RecommendMultiViewImageViewHolder>(
-    RecommendPlaceDiffUtilCallback()
-) {
+class RecommendMultiViewImageAdapter(private val onItemClickListener: OnItemClickListener) :
+    ListAdapter<RecommendPlace, RecommendMultiViewImageAdapter.RecommendMultiViewImageViewHolder>(
+        RecommendPlaceDiffUtilCallback()
+    ) {
     interface OnItemClickListener {
         fun onItemClick(item: RecommendPlace)
     }
-    class RecommendMultiViewImageViewHolder(val binding: ItemRecyclerGuideRecommendPlaceBinding) : RecyclerView.ViewHolder(binding.root) {
+
+    class RecommendMultiViewImageViewHolder(val binding: ItemRecyclerGuideRecommendPlaceBinding) :
+        RecyclerView.ViewHolder(binding.root) {
         fun bind(item: RecommendPlace) {
             binding.item = item
             binding.executePendingBindings()
         }
     }
+
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int
@@ -168,6 +176,7 @@ class RecommendMultiViewImageAdapter(private val onItemClickListener: OnItemClic
         }
     }
 }
+
 class AllPlaceMultiViewImageAdapter(
     private val onItemClickListener: OnItemClickListener
 ) : ListAdapter<Place, AllPlaceMultiViewImageAdapter.AllPlaceMultiImageViewHolder>(
@@ -177,7 +186,8 @@ class AllPlaceMultiViewImageAdapter(
         fun onItemClick(item: Place)
     }
 
-    class AllPlaceMultiImageViewHolder(val binding: ItemRecyclerGuidePlaceAllBinding) : RecyclerView.ViewHolder(binding.root) {
+    class AllPlaceMultiImageViewHolder(val binding: ItemRecyclerGuidePlaceAllBinding) :
+        RecyclerView.ViewHolder(binding.root) {
         fun bind(item: Place) {
             binding.item = item
             binding.executePendingBindings()
@@ -202,7 +212,18 @@ class AllPlaceMultiViewImageAdapter(
         }
     }
 }
-class GuideDiffUtilCallback : DiffUtil.ItemCallback<Guide>() {
+
+private class GuideMultiViewDiffUtil() : DiffUtil.ItemCallback<Guide>() {
+    override fun areItemsTheSame(oldItem: Guide, newItem: Guide): Boolean {
+        return oldItem === newItem
+    }
+
+    override fun areContentsTheSame(oldItem: Guide, newItem: Guide): Boolean {
+        return oldItem == newItem
+    }
+}
+
+private class GuideDiffUtilCallback : DiffUtil.ItemCallback<Guide>() {
     override fun areItemsTheSame(oldItem: Guide, newItem: Guide): Boolean {
         return oldItem.hashCode() == newItem.hashCode()
     }
@@ -211,7 +232,8 @@ class GuideDiffUtilCallback : DiffUtil.ItemCallback<Guide>() {
         return oldItem == newItem
     }
 }
-class RecommendPlaceDiffUtilCallback : DiffUtil.ItemCallback<RecommendPlace>() {
+
+private class RecommendPlaceDiffUtilCallback : DiffUtil.ItemCallback<RecommendPlace>() {
     override fun areItemsTheSame(oldItem: RecommendPlace, newItem: RecommendPlace): Boolean {
         return oldItem.name == newItem.name
     }

--- a/app/src/main/java/com/thequietz/travelog/guide/adapter/OtherInfoAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/adapter/OtherInfoAdapter.kt
@@ -3,6 +3,7 @@ package com.thequietz.travelog.guide.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.navigation.findNavController
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.google.gson.Gson
 import com.thequietz.travelog.databinding.ItemRecyclerOtherInfoBinding
@@ -10,10 +11,12 @@ import com.thequietz.travelog.guide.RecommendPlace
 import com.thequietz.travelog.guide.view.OtherInfoFragmentDirections
 import com.thequietz.travelog.place.model.PlaceRecommendModel
 
-class OtherInfoAdapter : androidx.recyclerview.widget.ListAdapter<RecommendPlace, OtherInfoAdapter.OtherInfoViewHolder>(
-    RecommendPlaceDiffUtilCallback()
-) {
-    class OtherInfoViewHolder(val binding: ItemRecyclerOtherInfoBinding) : RecyclerView.ViewHolder(binding.root) {
+class OtherInfoAdapter :
+    androidx.recyclerview.widget.ListAdapter<RecommendPlace, OtherInfoAdapter.OtherInfoViewHolder>(
+        OtherInfoDiffUtilCallback()
+    ) {
+    class OtherInfoViewHolder(val binding: ItemRecyclerOtherInfoBinding) :
+        RecyclerView.ViewHolder(binding.root) {
         fun bind(item: RecommendPlace) {
             binding.item = item
             binding.executePendingBindings()
@@ -37,6 +40,7 @@ class OtherInfoAdapter : androidx.recyclerview.widget.ListAdapter<RecommendPlace
             }
         }
     }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OtherInfoViewHolder {
         return OtherInfoViewHolder(
             ItemRecyclerOtherInfoBinding.inflate(
@@ -47,5 +51,15 @@ class OtherInfoAdapter : androidx.recyclerview.widget.ListAdapter<RecommendPlace
 
     override fun onBindViewHolder(holder: OtherInfoViewHolder, position: Int) {
         holder.bind(getItem(position))
+    }
+}
+
+private class OtherInfoDiffUtilCallback : DiffUtil.ItemCallback<RecommendPlace>() {
+    override fun areItemsTheSame(oldItem: RecommendPlace, newItem: RecommendPlace): Boolean {
+        return oldItem.name == newItem.name
+    }
+
+    override fun areContentsTheSame(oldItem: RecommendPlace, newItem: RecommendPlace): Boolean {
+        return oldItem == newItem
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/guide/view/GuideFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/view/GuideFragment.kt
@@ -28,10 +28,9 @@ class GuideFragment : Fragment() {
     private val binding get() = _binding!!
 
     private val guideViewModel by viewModels<GuideViewModel>()
-    private val adapter by lazy { GuideMultiViewAdapter(this) }
     lateinit var loading: LoadingDialog
 
-    private lateinit var _context: Context
+    private var _context: Context? = null
     private var _inputManager: InputMethodManager? = null
     private val inputManager get() = _inputManager!!
 
@@ -40,14 +39,17 @@ class GuideFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        _context = requireContext()
         _binding = FragmentGuideBinding.inflate(inflater, container, false)
-        loading = LoadingDialog(requireContext())
-        if (!TravelogApplication.prefs.loadGuideLoadingState()) {
-            loading.show()
-            Handler(Looper.getMainLooper()).postDelayed({
-                loading.dismiss()
-                TravelogApplication.prefs.disableGuideLoadingState()
-            }, 4000)
+        _context?.also {
+            loading = LoadingDialog(it)
+            if (!TravelogApplication.prefs.loadGuideLoadingState()) {
+                loading.show()
+                Handler(Looper.getMainLooper()).postDelayed({
+                    loading.dismiss()
+                    TravelogApplication.prefs.disableGuideLoadingState()
+                }, 4000)
+            }
         }
 
         return binding.root
@@ -55,8 +57,10 @@ class GuideFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        _context = requireContext()
-        _inputManager = _context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+
+        val adapter = GuideMultiViewAdapter()
+        _inputManager =
+            _context?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
 
         with(binding) {
             lifecycleOwner = viewLifecycleOwner
@@ -105,7 +109,7 @@ class GuideFragment : Fragment() {
 
     private fun searchAction() {
         if (binding.etSearch.text.toString().trim() == "") {
-            Toast.makeText(requireContext(), "검색어를 입력하세요!", Toast.LENGTH_SHORT).show()
+            Toast.makeText(_context, "검색어를 입력하세요!", Toast.LENGTH_SHORT).show()
         } else {
             val action = GuideFragmentDirections
                 .actionGuideFragmentToSpecificGuideFragment(binding.etSearch.text.toString())
@@ -122,5 +126,6 @@ class GuideFragment : Fragment() {
 
         _inputManager = null
         _binding = null
+        _context = null
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/guide/view/GuideFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/view/GuideFragment.kt
@@ -24,20 +24,23 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class GuideFragment : Fragment() {
-    private lateinit var binding: FragmentGuideBinding
+    private var _binding: FragmentGuideBinding? = null
+    private val binding get() = _binding!!
+
     private val guideViewModel by viewModels<GuideViewModel>()
     private val adapter by lazy { GuideMultiViewAdapter(this) }
     lateinit var loading: LoadingDialog
 
     private lateinit var _context: Context
-    private lateinit var inputManager: InputMethodManager
+    private var _inputManager: InputMethodManager? = null
+    private val inputManager get() = _inputManager!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentGuideBinding.inflate(inflater, container, false)
+        _binding = FragmentGuideBinding.inflate(inflater, container, false)
         loading = LoadingDialog(requireContext())
         if (!TravelogApplication.prefs.loadGuideLoadingState()) {
             loading.show()
@@ -53,7 +56,7 @@ class GuideFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _context = requireContext()
-        inputManager = _context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        _inputManager = _context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
 
         with(binding) {
             lifecycleOwner = viewLifecycleOwner
@@ -111,8 +114,13 @@ class GuideFragment : Fragment() {
     }
 
     private fun closeKeyboard() {
-        val mInputMethodManager: InputMethodManager =
-            requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        mInputMethodManager.hideSoftInputFromWindow(binding.etSearch.windowToken, 0)
+        inputManager.hideSoftInputFromWindow(binding.etSearch.windowToken, 0)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        _inputManager = null
+        _binding = null
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/guide/view/OtherInfoFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/view/OtherInfoFragment.kt
@@ -28,8 +28,8 @@ import kotlinx.coroutines.withContext
 
 @AndroidEntryPoint
 class OtherInfoFragment : Fragment() {
-    private lateinit var _binding: FragmentOtherInfoBinding
-    private val binding get() = _binding
+    private var _binding: FragmentOtherInfoBinding? = null
+    private val binding get() = _binding!!
     private val otherInfoViewModel by viewModels<OtherInfoViewModel>()
     private val args: OtherInfoFragmentArgs by navArgs()
     private val vacationAdapter by lazy { OtherInfoAdapter() }
@@ -191,5 +191,11 @@ class OtherInfoFragment : Fragment() {
                 it.findNavController().navigate(action)
             }
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        _binding = null
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/guide/view/SpecificGuideFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/view/SpecificGuideFragment.kt
@@ -14,8 +14,8 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class SpecificGuideFragment : Fragment() {
-    private lateinit var _binding: FragmentSpecificGuideBinding
-    private val binding get() = _binding
+    private var _binding: FragmentSpecificGuideBinding? = null
+    private val binding get() = _binding!!
     private val specificGuideViewModel by viewModels<SpecificGuideViewModel>()
     private val args: SpecificGuideFragmentArgs by navArgs()
     private val adapter by lazy { AllPlaceAdapter() }

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceDetailFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceDetailFragment.kt
@@ -7,6 +7,9 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.GoogleMapOptions
+import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.material.appbar.AppBarLayout
 import com.google.gson.Gson
@@ -32,12 +35,23 @@ class PlaceDetailFragment : GoogleMapFragment<FragmentPlaceDetailBinding, PlaceD
     private val navArgs: PlaceDetailFragmentArgs by navArgs()
 
     private var isRecommended: Boolean = false
+    private var mapFragment: SupportMapFragment? = null
     private lateinit var adapter: PlaceDetailAdapter
 
     private lateinit var searchModel: PlaceSearchModel
     private lateinit var recommendModel: PlaceRecommendModel
 
     private lateinit var gson: Gson
+
+    override fun onMapReady(googleMap: GoogleMap) {
+        super.onMapReady(googleMap)
+
+        mapFragment = childFragmentManager.findFragmentById(R.id.fragment_map) as SupportMapFragment
+        mapFragment = mapFragment?.also {
+            val mapOptions = GoogleMapOptions().useViewLifecycleInFragment(true)
+            SupportMapFragment.newInstance(mapOptions)
+        }
+    }
 
     override fun initViewModel() {
         binding.viewModel = viewModel
@@ -166,6 +180,13 @@ class PlaceDetailFragment : GoogleMapFragment<FragmentPlaceDetailBinding, PlaceD
                 }
             }
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        map.clear()
+        mapFragment?.onDestroyView()
     }
 }
 

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceRecommendFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceRecommendFragment.kt
@@ -89,4 +89,10 @@ class PlaceRecommendFragment : Fragment() {
             }
         }
     }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        _binding = null
+    }
 }

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
@@ -14,6 +14,8 @@ import androidx.navigation.ui.setupWithNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.GoogleMapOptions
+import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
 import com.google.gson.Gson
 import com.thequietz.travelog.R
@@ -44,12 +46,10 @@ class PlaceSearchFragment : GoogleMapFragment<FragmentPlaceSearchBinding, PlaceS
     private lateinit var inputManager: InputMethodManager
 
     private val navArgs: PlaceSearchFragmentArgs by navArgs()
-    private var googleMap: GoogleMap? = null
+    private var mapFragment: SupportMapFragment? = null
 
     override fun onMapReady(googleMap: GoogleMap) {
         super.onMapReady(googleMap)
-
-        this.googleMap = googleMap
 
         if (navArgs.schedulePlaceArray.isEmpty()) {
             return
@@ -84,6 +84,12 @@ class PlaceSearchFragment : GoogleMapFragment<FragmentPlaceSearchBinding, PlaceS
             }
             true
         }
+
+        mapFragment = childFragmentManager.findFragmentById(R.id.fragment_map) as SupportMapFragment
+        mapFragment = mapFragment?.also {
+            val mapOptions = GoogleMapOptions().useViewLifecycleInFragment(true)
+            SupportMapFragment.newInstance(mapOptions)
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -96,7 +102,7 @@ class PlaceSearchFragment : GoogleMapFragment<FragmentPlaceSearchBinding, PlaceS
         locationAdapter = PlaceLocationAdapter(object : PlaceLocationAdapter.OnItemClickListener {
             override fun onItemClick(model: SchedulePlaceModel) {
                 viewModel.selectLocation(model)
-                googleMap?.moveCamera(CameraUpdateFactory.newLatLng(LatLng(model.mapY, model.mapX)))
+                map.moveCamera(CameraUpdateFactory.newLatLng(LatLng(model.mapY, model.mapX)))
             }
         })
 
@@ -198,6 +204,7 @@ class PlaceSearchFragment : GoogleMapFragment<FragmentPlaceSearchBinding, PlaceS
     override fun onDestroyView() {
         super.onDestroyView()
 
-        googleMap = null
+        map.clear()
+        mapFragment?.onDestroyView()
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
@@ -194,4 +194,10 @@ class PlaceSearchFragment : GoogleMapFragment<FragmentPlaceSearchBinding, PlaceS
     override fun initTargetList() {
         baseTargetList = mutableListOf()
     }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        googleMap = null
+    }
 }

--- a/app/src/main/java/com/thequietz/travelog/schedule/adapter/ScheduleRecyclerAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/adapter/ScheduleRecyclerAdapter.kt
@@ -11,7 +11,7 @@ import com.thequietz.travelog.schedule.model.ScheduleModel
 class ScheduleRecyclerAdapter(
     val onClick: (ScheduleModel) -> (Unit),
     val onDelete: (Int) -> (Unit)
-) : ListAdapter<ScheduleModel, RecyclerView.ViewHolder>(diffUtil) {
+) : ListAdapter<ScheduleModel, RecyclerView.ViewHolder>(ScheduleRecyclerDiffUtil()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return ScheduleViewHolder(
@@ -27,14 +27,12 @@ class ScheduleRecyclerAdapter(
         val schedule = getItem(position)
         (holder as ScheduleViewHolder).bind(schedule)
     }
+}
 
-    companion object {
-        private val diffUtil = object : DiffUtil.ItemCallback<ScheduleModel>() {
-            override fun areItemsTheSame(oldItem: ScheduleModel, newItem: ScheduleModel) =
-                oldItem.id == newItem.id
+private class ScheduleRecyclerDiffUtil : DiffUtil.ItemCallback<ScheduleModel>() {
+    override fun areItemsTheSame(oldItem: ScheduleModel, newItem: ScheduleModel) =
+        oldItem.id == newItem.id
 
-            override fun areContentsTheSame(oldItem: ScheduleModel, newItem: ScheduleModel) =
-                oldItem == newItem
-        }
-    }
+    override fun areContentsTheSame(oldItem: ScheduleModel, newItem: ScheduleModel) =
+        oldItem == newItem
 }

--- a/app/src/main/java/com/thequietz/travelog/schedule/view/ScheduleDetailFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/view/ScheduleDetailFragment.kt
@@ -143,7 +143,9 @@ class ScheduleDetailFragment :
     }
 
     override fun onDestroyView() {
-        binding.rvSchedule.adapter = null
         super.onDestroyView()
+
+        baseTargetList.clear()
+        binding.rvSchedule.adapter = null
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/schedule/view/ScheduleFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/view/ScheduleFragment.kt
@@ -45,8 +45,9 @@ class ScheduleFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        _binding = null
         super.onDestroyView()
+
+        _binding = null
     }
 
     private fun initRecyclerView() {

--- a/app/src/main/java/com/thequietz/travelog/schedule/view/SchedulePlaceFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/view/SchedulePlaceFragment.kt
@@ -147,4 +147,10 @@ class SchedulePlaceFragment : Fragment() {
         viewModel.loadPlaceList()
         viewModel.initPlaceSelectedList()
     }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        _binding = null
+    }
 }

--- a/app/src/main/java/com/thequietz/travelog/schedule/view/ScheduleSelectFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/view/ScheduleSelectFragment.kt
@@ -27,7 +27,9 @@ import java.util.TimeZone
 
 @AndroidEntryPoint
 class ScheduleSelectFragment : Fragment() {
-    private lateinit var binding: FragmentScheduleSelectBinding
+    private var _binding: FragmentScheduleSelectBinding? = null
+    private val binding get() = _binding!!
+
     private val scheduleSelectViewModel by viewModels<ScheduleSelectViewModel>()
     private val args: ScheduleSelectFragmentArgs by navArgs()
 
@@ -36,7 +38,7 @@ class ScheduleSelectFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        binding =
+        _binding =
             DataBindingUtil.inflate(inflater, R.layout.fragment_schedule_select, container, false)
         initEditText()
         initDatePicker()
@@ -124,5 +126,11 @@ class ScheduleSelectFragment : Fragment() {
         binding.calendar.setOnStartSelectedListener { startDate, _ ->
             scheduleSelectViewModel.setScheduleRange(startDate, startDate)
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        _binding = null
     }
 }

--- a/app/src/main/res/layout/fragment_place_detail.xml
+++ b/app/src/main/res/layout/fragment_place_detail.xml
@@ -21,39 +21,46 @@
             android:id="@+id/abl_place_detail"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginVertical="0dp"
             android:fitsSystemWindows="true">
 
             <com.google.android.material.appbar.CollapsingToolbarLayout
                 android:id="@+id/tbl_place_detail"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="0dp"
+                android:contentInsetEnd="0dp"
+                android:contentInsetRight="0dp"
                 android:fitsSystemWindows="true"
+                android:paddingVertical="0dp"
+                app:contentInsetEnd="0dp"
+                app:contentInsetRight="0dp"
                 app:contentScrim="?attr/colorPrimary"
                 app:expandedTitleTextAppearance="@android:color/transparent"
-                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+                app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
 
                 <LinearLayout
                     android:id="@+id/ll_google_map_detail"
                     android:layout_width="match_parent"
                     android:layout_height="500dp"
-                    android:background="@color/purple_200"
-                    android:fitsSystemWindows="true"
+                    android:layout_marginVertical="0dp"
                     android:gravity="center_vertical"
                     android:orientation="vertical"
+                    android:padding="0dp"
                     app:layout_collapseMode="parallax"
+                    app:layout_collapseParallaxMultiplier="1"
                     app:layout_constraintBottom_toTopOf="@id/ll_place_detail"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintVertical_chainStyle="packed"
-                    app:layout_scrollFlags="scroll|exitUntilCollapsed">
+                    app:layout_scrollFlags="scroll|enterAlways">
 
                     <fragment
                         android:id="@+id/fragment_map"
                         android:name="com.google.android.gms.maps.SupportMapFragment"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
-                        android:layout_marginTop="10dp"
                         tools:layout="@layout/abc_search_view" />
 
                 </LinearLayout>
@@ -62,8 +69,11 @@
                     android:id="@+id/tb_place_detail"
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
+                    android:layout_marginVertical="0dp"
+                    android:paddingVertical="0dp"
                     app:layout_collapseMode="pin"
-                    app:title="@{viewModel.detail.name}"/>
+                    app:title="@{viewModel.detail.name}"
+                    app:titleMarginBottom="0dp" />
 
             </com.google.android.material.appbar.CollapsingToolbarLayout>
 
@@ -74,6 +84,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_gravity="fill_vertical"
+            android:paddingTop="20dp"
             android:paddingBottom="60dp"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
@@ -85,7 +96,7 @@
                 android:orientation="vertical"
                 android:paddingHorizontal="20dp"
                 android:paddingTop="10dp"
-                android:paddingBottom="30dp"
+                android:paddingBottom="10dp"
                 app:layout_constraintBottom_toTopOf="@id/btn_place_add"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_place_search.xml
+++ b/app/src/main/res/layout/fragment_place_search.xml
@@ -62,11 +62,11 @@
             android:id="@+id/rv_place_search"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="30dp"
             android:paddingHorizontal="8dp"
+            android:paddingVertical="10dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHeight_max="300dp"
+            app:layout_constraintHeight_max="360dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/ll_google_map"
             tools:listitem="@layout/item_recycler_place_search" />

--- a/app/src/main/res/navigation/schedule.xml
+++ b/app/src/main/res/navigation/schedule.xml
@@ -99,7 +99,7 @@
     <fragment
         android:id="@+id/confirmFragment"
         android:name="com.thequietz.travelog.confirm.view.ConfirmFragment"
-        android:label="ConfirmFragment" >
+        android:label="ConfirmFragment">
         <argument
             android:name="schedule"
             app:argType="com.thequietz.travelog.schedule.model.ScheduleModel" />


### PR DESCRIPTION
# #155 #156

## 작업 내용
- 지도 프래그먼트가 해당 화면을 담당하는 프래그먼트가 onDestroyView를 호출할 때 지도와 지도 프래그먼트도 정리
- 장소 정보 상세 화면에서 기본 툴바가 뜨지 않게 함. 초기 화면에서 지도 주변에 나타나는 여백 제거 및 제목 투명화
- 기타 여러 화면에서 발생할 수 있는 메모리 누수 이슈 관리
  - 동반 객체를 Private 클래스로 변경
  - 프래그먼트 onDestroyView 호출할 때 binding null로 변경