### PR TITLE
#164 #165 [일정 설정 완료 화면] 관광지 없을 때 임시 좌표 사용

### DIFF
--- a/app/src/main/java/com/thequietz/travelog/MainActivity.kt
+++ b/app/src/main/java/com/thequietz/travelog/MainActivity.kt
@@ -57,6 +57,10 @@ class MainActivity : AppCompatActivity() {
                 R.id.placeRecommendFragment,
                 R.id.placeSearchFragment,
                 R.id.recordBasicFragment -> binding.toolbar.visibility = View.GONE
+                R.id.placeDetailFragment,
+                R.id.placeDetailFragmentFromGuide -> {
+                    binding.toolbar.visibility = View.GONE
+                }
                 else -> binding.toolbar.title = ""
             }
         }

--- a/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
@@ -101,6 +101,8 @@ class ConfirmFragment : GoogleMapFragment<FragmentConfirmBinding, ConfirmViewMod
 
         viewModel.currentSchedule.observe(viewLifecycleOwner, {
             if (it.isNullOrEmpty()) {
+                val (_, _, mapX, mapY) = navArgs.defaultPlace
+                targetList.value = mutableListOf(LatLng(mapY, mapX))
                 binding.llConfirmNoItems.visibility = View.VISIBLE
                 binding.tvConfirmNoItems.visibility = View.VISIBLE
                 binding.vpConfirmPlace.visibility = View.GONE

--- a/app/src/main/java/com/thequietz/travelog/guide/view/GuideFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/view/GuideFragment.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -14,7 +15,9 @@ import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.thequietz.travelog.LoadingDialog
+import com.thequietz.travelog.R
 import com.thequietz.travelog.TravelogApplication
 import com.thequietz.travelog.databinding.FragmentGuideBinding
 import com.thequietz.travelog.guide.adapter.GuideMultiViewAdapter
@@ -66,6 +69,25 @@ class GuideFragment : Fragment() {
                 it?.let { adapter.submitList(it) }
             })
         }
+
+        findNavController().apply {
+            currentBackStackEntry?.savedStateHandle
+                ?.also {
+                    it.getLiveData<Boolean>("toSchedulePlace").observe(
+                        viewLifecycleOwner,
+                        { isClicked ->
+                            if (isClicked) {
+                                Log.d("TAG", "Move to Schedule")
+                                it.remove<Boolean>("toSchedulePlace")
+                                requireActivity()
+                                    .findViewById<BottomNavigationView>(R.id.bottom_navigation)
+                                    .selectedItemId = R.id.schedule
+                            }
+                        }
+                    )
+                }
+        }
+
         setClickListener()
     }
 

--- a/app/src/main/java/com/thequietz/travelog/guide/view/OtherInfoFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/view/OtherInfoFragment.kt
@@ -8,6 +8,7 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.findNavController
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -71,6 +72,14 @@ class OtherInfoFragment : Fragment() {
                 it?.let { festivalAdapter.submitList(it) }
             })
         }
+
+        binding.btnMakePlan.setOnClickListener {
+            findNavController().apply {
+                previousBackStackEntry?.savedStateHandle?.set("toSchedulePlace", true)
+                popBackStack()
+            }
+        }
+
         setListener()
     }
 
@@ -82,7 +91,8 @@ class OtherInfoFragment : Fragment() {
                     with(binding.rvVacationSpot) {
                         val visibleItemCount = childCount
                         val totalItemCount = layoutManager?.itemCount!!
-                        val firstVisibleItem = (layoutManager as LinearLayoutManager).findFirstVisibleItemPosition()
+                        val firstVisibleItem =
+                            (layoutManager as LinearLayoutManager).findFirstVisibleItemPosition()
                         if (totalItemCount <= (firstVisibleItem + visibleItemCount) && (visibleItemCount - vacationPrevItemCount == 1)) {
                             otherInfoViewModel.addVacationData()
                         }
@@ -102,7 +112,8 @@ class OtherInfoFragment : Fragment() {
                     with(binding.rvFood) {
                         val visibleItemCount = childCount
                         val totalItemCount = layoutManager?.itemCount!!
-                        val firstVisibleItem = (layoutManager as LinearLayoutManager).findFirstVisibleItemPosition()
+                        val firstVisibleItem =
+                            (layoutManager as LinearLayoutManager).findFirstVisibleItemPosition()
                         if (totalItemCount <= (firstVisibleItem + visibleItemCount) && (visibleItemCount - foodPrevItemCount == 1)) {
                             otherInfoViewModel.addFoodData()
                         }
@@ -122,7 +133,8 @@ class OtherInfoFragment : Fragment() {
                     with(binding.rvFestival) {
                         val visibleItemCount = childCount
                         val totalItemCount = layoutManager?.itemCount!!
-                        val firstVisibleItem = (layoutManager as LinearLayoutManager).findFirstVisibleItemPosition()
+                        val firstVisibleItem =
+                            (layoutManager as LinearLayoutManager).findFirstVisibleItemPosition()
                         if (totalItemCount <= (firstVisibleItem + visibleItemCount) && (visibleItemCount - festivalPrevItemCount == 1)) {
                             otherInfoViewModel.addFestivalData()
                         }
@@ -169,11 +181,6 @@ class OtherInfoFragment : Fragment() {
             slLayout.setOnRefreshListener {
                 otherInfoViewModel.initPlace(thisPlace)
                 slLayout.isRefreshing = false
-            }
-            btnMakePlan.setOnClickListener {
-                val action = OtherInfoFragmentDirections
-                    .actionOtherInfoFragmentToSchedulePlaceFragmentFromGuide()
-                it.findNavController().navigate(action)
             }
         }
     }

--- a/app/src/main/java/com/thequietz/travelog/guide/view/SpecificGuideFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/guide/view/SpecificGuideFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.thequietz.travelog.databinding.FragmentSpecificGuideBinding
 import com.thequietz.travelog.guide.adapter.AllPlaceAdapter
@@ -41,6 +42,17 @@ class SpecificGuideFragment : Fragment() {
                 it?.let { adapter.submitList(it) }
             })
             initCurrentItem(args)
+        }
+
+        findNavController().apply {
+            currentBackStackEntry?.savedStateHandle
+                ?.getLiveData<Boolean>("toSchedulePlace")?.observe(
+                    viewLifecycleOwner,
+                    {
+                        previousBackStackEntry?.savedStateHandle?.set("toSchedulePlace", it)
+                        popBackStack()
+                    }
+                )
         }
     }
 }

--- a/app/src/main/java/com/thequietz/travelog/schedule/view/ScheduleDetailFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/schedule/view/ScheduleDetailFragment.kt
@@ -90,7 +90,7 @@ class ScheduleDetailFragment :
 
                     val action =
                         ScheduleDetailFragmentDirections.actionScheduleDetailFragmentToConfirmFragment(
-                            schedule, scheduleDetails
+                            schedule, scheduleDetails, args.schedulePlaceArray[0]
                         )
                     navController.navigate(action)
                     return@setOnMenuItemClickListener true

--- a/app/src/main/res/navigation/guide.xml
+++ b/app/src/main/res/navigation/guide.xml
@@ -41,16 +41,9 @@
             app:popUpTo="@id/specificGuideFragment"
             app:popUpToInclusive="true" />
         <action
-            android:id="@+id/action_otherInfoFragment_to_schedulePlaceFragmentFromGuide"
-            app:destination="@id/schedulePlaceFragmentFromGuide" />
-        <action
             android:id="@+id/action_otherInfoFragment_to_placeDetailFragmentFromGuide"
             app:destination="@id/placeDetailFragmentFromGuide" />
     </fragment>
-    <fragment
-        android:id="@+id/schedulePlaceFragmentFromGuide"
-        android:name="com.thequietz.travelog.schedule.view.SchedulePlaceFragment"
-        android:label="SchedulePlaceFragment" />
     <fragment
         android:id="@+id/placeDetailFragmentFromGuide"
         android:name="com.thequietz.travelog.place.view.PlaceDetailFragment"

--- a/app/src/main/res/navigation/schedule.xml
+++ b/app/src/main/res/navigation/schedule.xml
@@ -111,6 +111,9 @@
             app:destination="@id/scheduleFragment"
             app:popUpTo="@id/scheduleFragment"
             app:popUpToInclusive="true" />
+        <argument
+            android:name="defaultPlace"
+            app:argType="com.thequietz.travelog.schedule.model.SchedulePlaceModel" />
     </fragment>
 
 </navigation>


### PR DESCRIPTION
# #164 #165

## 작업내용
- 일정 설정 완료 화면에서 각 여행일자에 대해 선택된 관광지가 없을 경우 여행 지역 선택 화면에서 가져온 임시 좌표 사용
- 임시 좌표로 지도 이동 확인

- 여행 지역별 화면에서 "일정 짜기" 버튼 클릭하면 백 스택에서 프래그먼트를 하나씩 꺼내 가이드 화면으로 이동
- 가이드 화면에 도착하고 나서 StateHandle에 들어있는 값이 true이면 여행 일정 화면으로 이동, 키는 "toSchedulePlace"
- 여행 일정이 잘 생성되는지 확인