### PR TITLE
#176 [여행 기록 기본 화면] 데이터베이스 갱신 오류 수정

### DIFF
--- a/app/src/main/java/com/thequietz/travelog/data/db/dao/NewRecordImageDao.kt
+++ b/app/src/main/java/com/thequietz/travelog/data/db/dao/NewRecordImageDao.kt
@@ -29,6 +29,9 @@ abstract class NewRecordImageDao : BaseDao<NewRecordImage> {
 
     @Query("UPDATE NewRecordImage SET comment =:comment WHERE newRecordImageId =:id")
     abstract fun updateRecordImageCommentById(comment: String, id: Int)
+
+    @Query("DELETE FROM NewRecordImage WHERE newTravelId =:travelId AND isDefault =:isDefault")
+    abstract fun deleteNewRecordImageByTravelIdAndIsDefault(travelId: Int, isDefault: Boolean)
 }
 
 @Dao

--- a/app/src/main/java/com/thequietz/travelog/record/adapter/RecordPhotoAdapter.kt
+++ b/app/src/main/java/com/thequietz/travelog/record/adapter/RecordPhotoAdapter.kt
@@ -1,6 +1,7 @@
 package com.thequietz.travelog.record.adapter
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -36,6 +37,11 @@ class RecordPhotoAdapter(
                 if (url == null) {
                     addImage?.invoke()
                 }
+            }
+
+            if (url == "empty") {
+                ivItemRecordPhoto.visibility = View.GONE
+                return@with
             }
 
             if (url != null) {

--- a/app/src/main/java/com/thequietz/travelog/record/repository/RecordBasicRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/record/repository/RecordBasicRepository.kt
@@ -1,5 +1,6 @@
 package com.thequietz.travelog.record.repository
 
+import com.thequietz.travelog.data.db.dao.NewRecordImage
 import com.thequietz.travelog.data.db.dao.NewRecordImageDao
 import com.thequietz.travelog.data.db.dao.RecordImageDao
 import com.thequietz.travelog.data.db.dao.ScheduleDao
@@ -30,6 +31,10 @@ class RecordBasicRepository @Inject constructor(
 
     fun insertRecordImages(images: List<RecordImage>) {
         coroutineScope.launch { recordImageDao.insert(*images.toTypedArray()) }
+    }
+
+    fun insertNewRecordImages(images: List<NewRecordImage>) {
+        coroutineScope.launch { newRecordImageDao.insert(*images.toTypedArray()) }
     }
 
     fun deleteRecordImageById(id: Int) {

--- a/app/src/main/java/com/thequietz/travelog/record/repository/RecordBasicRepository.kt
+++ b/app/src/main/java/com/thequietz/travelog/record/repository/RecordBasicRepository.kt
@@ -49,4 +49,10 @@ class RecordBasicRepository @Inject constructor(
             recordImageDao.deleteRecordImageByTravelId(travelId)
         }
     }
+
+    fun deleteNewRecordImageByTravelIdAndIsDefault(travelId: Int, isDefault: Boolean) {
+        coroutineScope.launch {
+            newRecordImageDao.deleteNewRecordImageByTravelIdAndIsDefault(travelId, isDefault)
+        }
+    }
 }

--- a/app/src/main/java/com/thequietz/travelog/record/view/RecordBasicFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/record/view/RecordBasicFragment.kt
@@ -1,7 +1,9 @@
 package com.thequietz.travelog.record.view
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.widget.Toast
 import androidx.appcompat.widget.PopupMenu
 import androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -117,6 +119,15 @@ class RecordBasicFragment : GoogleMapFragment<FragmentRecordBasicBinding, Record
     override var isMarkerNumbered = true
     override var drawOrderedPolyline = true
 
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        viewModel.loadData(navArgs.travelId, navArgs.title, navArgs.startDate, navArgs.endDate)
+        return super.onCreateView(inflater, container, savedInstanceState)
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         loadingDialog.show()
         super.onViewCreated(view, savedInstanceState)
@@ -178,7 +189,6 @@ class RecordBasicFragment : GoogleMapFragment<FragmentRecordBasicBinding, Record
     }
 
     override fun initViewModel() {
-        viewModel.loadData(navArgs.travelId, navArgs.title, navArgs.startDate, navArgs.endDate)
         subscribeUi()
     }
 

--- a/app/src/main/java/com/thequietz/travelog/record/view/RecordFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/record/view/RecordFragment.kt
@@ -30,7 +30,13 @@ class RecordFragment : Fragment(R.layout.fragment_record) {
         binding.rvRecord.adapter = adapter
 
         viewModel.loadData()
+
         viewModel.recordList.observe(viewLifecycleOwner) { recordList ->
+            if (recordList.isEmpty()) {
+                binding.tvNoRecord.visibility = View.VISIBLE
+            } else {
+                binding.tvNoRecord.visibility = View.INVISIBLE
+            }
             adapter.submitList(recordList)
         }
 

--- a/app/src/main/java/com/thequietz/travelog/record/viewmodel/RecordBasicViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/record/viewmodel/RecordBasicViewModel.kt
@@ -64,7 +64,7 @@ class RecordBasicViewModel @Inject constructor(
             if (!isSameOldAndNew) {
                 repository.deleteRecordImageByTravelId(travelId)
                 repository.insertRecordImages(newRecordImages)
-
+                repository.deleteNewRecordImageByTravelIdAndIsDefault(travelId, true)
                 val tempNewRecordImages = mutableListOf<NewRecordImage>()
                 newRecordImages.forEach { recordImage ->
                     tempNewRecordImages.add(

--- a/app/src/main/java/com/thequietz/travelog/record/viewmodel/RecordBasicViewModel.kt
+++ b/app/src/main/java/com/thequietz/travelog/record/viewmodel/RecordBasicViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.gms.maps.model.LatLng
-import com.thequietz.travelog.data.RecordRepository
 import com.thequietz.travelog.data.db.dao.NewRecordImage
 import com.thequietz.travelog.record.model.RecordBasic
 import com.thequietz.travelog.record.model.RecordBasicItem
@@ -17,14 +16,14 @@ import com.thequietz.travelog.util.createDayFromDate
 import com.thequietz.travelog.util.nextDate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
 class RecordBasicViewModel @Inject constructor(
-    private val repository: RecordBasicRepository,
-    private val recordRepository: RecordRepository
+    private val repository: RecordBasicRepository
 ) : ViewModel() {
     private val _isEmpty = MutableLiveData<Boolean>()
     val isEmpty: LiveData<Boolean> = _isEmpty
@@ -57,28 +56,34 @@ class RecordBasicViewModel @Inject constructor(
             val newRecordImages = createRecordImages(scheduleDetails, title, startDate, endDate)
             val isSameOldAndNew = compareOldAndNewRecordImages(oldRecordImages, newRecordImages)
 
-            withContext(Dispatchers.Main) {
-                _recordImageList.value = newRecordImages
+            if (!isSameOldAndNew) {
+                launch(Dispatchers.IO) {
+                    repository.deleteNewRecordImageByTravelIdAndIsDefault(travelId, true)
+                    val tempNewRecordImages = mutableListOf<NewRecordImage>()
+                    newRecordImages.forEach { recordImage ->
+                        tempNewRecordImages.add(
+                            NewRecordImage().copy(
+                                newTravelId = recordImage.travelId,
+                                newTitle = recordImage.title,
+                                newPlace = recordImage.place,
+                                url = "empty",
+                                comment = "코멘트를 남겨주세요!",
+                                isDefault = true
+                            )
+                        )
+                    }
+                    delay(500)
+                    repository.insertNewRecordImages(tempNewRecordImages.toList())
+                }
+                launch(Dispatchers.IO) {
+                    repository.deleteRecordImageByTravelId(travelId)
+                    delay(500)
+                    repository.insertRecordImages(newRecordImages)
+                }
             }
 
-            if (!isSameOldAndNew) {
-                repository.deleteRecordImageByTravelId(travelId)
-                repository.insertRecordImages(newRecordImages)
-                repository.deleteNewRecordImageByTravelIdAndIsDefault(travelId, true)
-                val tempNewRecordImages = mutableListOf<NewRecordImage>()
-                newRecordImages.forEach { recordImage ->
-                    tempNewRecordImages.add(
-                        NewRecordImage().copy(
-                            newTravelId = recordImage.travelId,
-                            newTitle = recordImage.title,
-                            newPlace = recordImage.place,
-                            url = "empty",
-                            comment = "코멘트를 남겨주세요!",
-                            isDefault = true
-                        )
-                    )
-                }
-                recordRepository.insertNewRecordImages(tempNewRecordImages)
+            withContext(Dispatchers.Main) {
+                _recordImageList.value = newRecordImages
             }
         }
     }

--- a/app/src/main/res/layout/fragment_record.xml
+++ b/app/src/main/res/layout/fragment_record.xml
@@ -4,23 +4,34 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:background="@color/white"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/white"
         tools:context=".record.view.RecordFragment">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_record"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_marginHorizontal="26dp"
-            android:paddingTop="30dp"
+            android:layout_marginHorizontal="20dp"
             android:clipToPadding="false"
             android:overScrollMode="never"
+            android:paddingTop="30dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:listitem="@layout/item_recycler_record" />
+
+        <TextView
+            android:id="@+id/tv_no_record"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="기록이 없어요!\n일정을 먼저 추가해주세요!"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/item_recycler_record.xml
+++ b/app/src/main/res/layout/item_recycler_record.xml
@@ -7,7 +7,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="3dp"
-        android:layout_marginBottom="30dp"
+        android:layout_marginBottom="20dp"
         android:background="@drawable/bg_white_round"
         android:elevation="5dp">
 


### PR DESCRIPTION
# #176 

## 진행 사항

- 데이터베이스 갱신 시 NewRecordImages 데이터베이스에서 초기 이미지 데이터만 삭제
- 썸네일에 임시 이미지 제외
- 여행 기록이 없는 경우 기록 목록 화면 가운데에 안내 텍스트 표시

## 오류 해결

### 문제1

RecordBasicFragment에서 장소 하나를 클릭하여 RecordViewOneFragment로 이동하고 이전 화면으로 돌아가면 리사이클러뷰 스크롤이 되지 않는 문제가 발생하였다.

### 해결 과정

내부 클래스로 정의되어있던 ScrollListener를 외부 클래스로 정의하고, onDestroyView()를 재정의하여 이 함수 안에 리사이클러뷰의 clearOnScrollListener()를 호출하여 등록했던 ScrollListener를 해제시켜주어 해결하였다.

---

### 문제2

ScheduleDetails 테이블과 RecordImages 테이블의 내용이 다른 경우 갱신이 필요하다. 갱신 하는 과정은 NewRecordImages 테이블과 RecordImages 테이블에서 각각 데이터를 삭제하고 새로운 데이터를 추가해주고 있다. 하지만 데이터를 삽입이 되지 않는 문제가 발생하였다.

### 해결 과정

데이터 삭제 후 500ms의 딜레이를 준 후 삽입하여 해결하였다.

테이블에서 쿼리문이 완료됬는지 결과를 받는 방법이 있다면 좋을 것 같다.