### PR TITLE
#209 [여행 기록 기본 화면] 디자인 개선

### DIFF
--- a/app/src/main/res/layout/fragment_record_basic.xml
+++ b/app/src/main/res/layout/fragment_record_basic.xml
@@ -31,7 +31,8 @@
                     android:layout_marginTop="?attr/actionBarSize"
                     android:orientation="vertical"
                     android:paddingBottom="10dp"
-                    app:layout_collapseMode="parallax">
+                    app:layout_collapseMode="parallax"
+                    app:layout_collapseParallaxMultiplier="0">
 
                     <TextView
                         android:id="@+id/tv_record_basic_title"

--- a/app/src/main/res/layout/fragment_record_basic.xml
+++ b/app/src/main/res/layout/fragment_record_basic.xml
@@ -39,7 +39,6 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="26dp"
-                        android:layout_marginTop="26dp"
                         android:textColor="@color/black"
                         android:textSize="28sp"
                         android:textStyle="bold"


### PR DESCRIPTION
# #209 

- 툴바와 여행 제목 간의 사이가 넓음
  - 여행 제목의 상단 마진 값 줄이기
- CollapsingToolbarLayout에서 Collapse 시에 여행 제목이 짤리면서 부자연스러움
  - Collapse 시에 제목이 스크롤에 따라 올라가도록 개선