### PR TITLE
Hotfix [일정 설정 완료 화면, 장소 검색 화면] 디자인 개선

### DIFF
--- a/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/confirm/view/ConfirmFragment.kt
@@ -25,7 +25,7 @@ class ConfirmFragment : GoogleMapFragment<FragmentConfirmBinding, ConfirmViewMod
     override val layoutId = R.layout.fragment_confirm
     override val viewModel: ConfirmViewModel by viewModels()
     override var drawMarker = true
-    override var isMarkerNumbered = false
+    override var isMarkerNumbered = true
     override var drawOrderedPolyline = false
 
     private var mapFragment: SupportMapFragment? = null
@@ -75,14 +75,12 @@ class ConfirmFragment : GoogleMapFragment<FragmentConfirmBinding, ConfirmViewMod
                         return
                     }
 
-                    val currentItem = viewModel.currentSchedule.value?.get(position)
-                    val location = currentItem?.destination?.geometry?.location
-                    val lat = location?.latitude
-                    val lng = location?.longitude
+                    val coordinates = viewModel.currentSchedule.value?.map { e ->
+                        val loc = e.destination.geometry.location
+                        LatLng(loc.latitude, loc.longitude)
+                    }?.toMutableList() ?: mutableListOf()
 
-                    if (lat != null && lng != null) {
-                        targetList.value = mutableListOf(LatLng(lat, lng))
-                    }
+                    targetList.value = coordinates
                 }
             })
 
@@ -117,14 +115,12 @@ class ConfirmFragment : GoogleMapFragment<FragmentConfirmBinding, ConfirmViewMod
                 }
             }
 
-            val currentItem = it.firstOrNull()
-            val location = currentItem?.destination?.geometry?.location
-            val lat = location?.latitude
-            val lng = location?.longitude
+            val coordinates = viewModel.currentSchedule.value?.map { e ->
+                val loc = e.destination.geometry.location
+                LatLng(loc.latitude, loc.longitude)
+            }?.toMutableList() ?: mutableListOf()
 
-            if (lat != null && lng != null) {
-                targetList.value = mutableListOf(LatLng(lat, lng))
-            }
+            targetList.value = coordinates
         })
 
         viewModel.getSchedulesByNavArgs(navArgs.schedule, navArgs.scheduleDetails)

--- a/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
+++ b/app/src/main/java/com/thequietz/travelog/place/view/PlaceSearchFragment.kt
@@ -60,12 +60,10 @@ class PlaceSearchFragment : GoogleMapFragment<FragmentPlaceSearchBinding, PlaceS
         }
         val initLocation = navArgs.schedulePlaceArray[0]
 
-        googleMap.moveCamera(
-            CameraUpdateFactory.newLatLng(
-                LatLng(
-                    initLocation.mapY,
-                    initLocation.mapX
-                )
+        baseTargetList = mutableListOf(
+            LatLng(
+                initLocation.mapY,
+                initLocation.mapX
             )
         )
 


### PR DESCRIPTION
# Hotfix

## 작업 내용

- 일정 설정 완료 화면
  - 각 여행일자마다 관광지 목록에 대한 마커들을 지도 화면에 전부 출력
  - 사용자가 추가한 순서대로 마커에 숫자 표시

- 장소 검색 화면
  - 지도 화면이 준비되면 사용자가 여행 지역 선택 화면에서 선택한 여행 지역들 중 첫번째 지역으로 시점 변경